### PR TITLE
fixes to select following anthony's comments

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModelInterface"
 uuid = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 authors = ["Thibaut Lienart and Anthony Blaom"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"

--- a/src/data_utils.jl
+++ b/src/data_utils.jl
@@ -248,7 +248,16 @@ depending on the value type. See also: [`selectrows`](@ref),
 """
 select(X, r, c) = select(get_interface_mode(), vtrait(X), X, r, c)
 
-select(::Mode, ::Val, X, r, c) = selectcols(selectrows(X, r), c)
+# only used here to denote "group of indices"
+const MIdx = Union{AbstractArray,Colon}
+
+select(::Mode, ::Val, X, r::MIdx, c)       = selectcols(selectrows(X, r), c)
+select(::Mode, ::Val, X, r, c::MIdx)       = selectcols(selectrows(X, r), c)
+select(::Mode, ::Val, X, r::MIdx, c::MIdx) = selectcols(selectrows(X, r), c)
+select(::Mode, ::Val, X, r, c) = _squeeze(selectcols(selectrows(X, r), c))
+
+_squeeze(::Nothing) = nothing
+_squeeze(v) = first(v)
 
 # ------------------------------------------------------------------------
 # UnivariateFinite

--- a/test/data_utils.jl
+++ b/test/data_utils.jl
@@ -98,7 +98,7 @@ end
     X = nothing
     @test selectrows(X, 1) === nothing
     @test selectcols(X, 1) === nothing
-    @test select(X, 1, 2) === nothing
+    @test select(X, 1, 2)  === nothing
 
     # vector
     X = ones(5)
@@ -116,7 +116,7 @@ end
     @test selectcols(X, 1)    == ones(5,)
     @test selectcols(X, 1:2)  == ones(5, 2)
     @test selectcols(X, :)   === X
-    @test select(X, 1, 1)     == [1.0]
+    @test select(X, 1, 1)     == 1.0
     @test select(X, 1:2, 1)   == ones(2,)
     @test select(X, 1:2, 1:2) == ones(2, 2)
 
@@ -131,7 +131,6 @@ end
     @test_throws ArgumentError selectcols(X, 1)
     @test_throws ArgumentError select(X, 1, 1)
 end
-# ------------------------------------------------------------------------
 @testset "select-full" begin
     setfull()
     M.selectrows(::FI, ::Val{:table}, X, ::Colon) = X
@@ -167,13 +166,31 @@ end
     @test selectcols(X, 1)   == [1,2,3]
     @test selectcols(X, 1:2) == (x = [1, 2, 3], y = [4, 5, 6])
     @test selectcols(X, :)  === X
-    @test select(X, 1, 1)    == [1]
+    @test select(X, 1, 1)    == 1
     @test select(X, 1:2, 1)  == [1,2]
     @test select(X, :, 1)    == [1,2,3]
     @test selectcols(X, :x)  == [1,2,3]
     @test select(X, 1:2, :z) == [0,0]
-end
+    #
+    # extra tests by Anthony
+    X = (x=[1,2,3], y=[10, 20, 30], z= [:a, :b, :c])
+    @test select(X, 2, :y)         == 20
+    @test select(X, 2, [:x, :y])   == (x=[2,], y=[20,])
+    @test select(X, 2:3, :x)       == [2, 3]
+    @test select(X, 2:3, [:x, :y]) == (x=[2, 3], y=[20, 30])
+    @test select(X, :, [:x, :y])   == select(X, 1:3, [:x, :y])
+    @test select(X, 2, :)          == select(X, 2, 1:3)
+    @test select(X, 2:3, :)        == select(X, 2:3, 1:3)
 
+    @test select(X, 2, 2)        == 20
+    @test select(X, 2, [1, 2])   == (x=[2,], y=[20,])
+    @test select(X, 2:3, 1)      == [2, 3]
+    @test select(X, 2:3, [1, 2]) == (x=[2, 3], y=[20, 30])
+    @test select(X, :, [1, 2])   == select(X, 1:3, [1, 2])
+    @test select(X, 2, :)        == select(X, 2, 1:3)
+    @test select(X, 2:3, :)      == select(X, 2:3, 1:3)
+end
+# ------------------------------------------------------------------------
 @testset "univ-finite" begin
     setlight()
     @test_throws M.InterfaceError UnivariateFinite(Dict(2=>3,3=>4))


### PR DESCRIPTION
Makes the implementation of `select` specialise to distinguish between "multi-index" and "single-index", when `select(X, r, c)` is used where both `r` and `c` are not `AbstractArray` or `Colon`, the result is "squeezed" to a  scalar with the corner case of `select(nothing, 1, 1)` which returns nothing anyway.

Anthony's specific batch of tests added. 