### PR TITLE
Now compatible with Tables 1.0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModelInterface"
 uuid = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 authors = ["Thibaut Lienart and Anthony Blaom"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"

--- a/test/data_utils.jl
+++ b/test/data_utils.jl
@@ -84,7 +84,7 @@ end
     X = ones(3,2)
     T = table(X)
     @test Tables.istable(T)
-    @test_broken Tables.matrix(T) == X
+    @test Tables.matrix(T) == X
 end
 # ------------------------------------------------------------------------
 @testset "nrows-light" begin


### PR DESCRIPTION
This only removes a `@test_broken` which is not broken anymore thanks to the release of Tables 1.0.2.