### PR TITLE
Add isrepresented method (version of `in` for MLJTypes)

### DIFF
--- a/src/MLJModelInterface.jl
+++ b/src/MLJModelInterface.jl
@@ -38,7 +38,7 @@ export matrix, int, classes, decoder, table,
        nrows, selectrows, selectcols, select
 
 # equality
-export is_same_except, isrespresented
+export is_same_except, isrepresented
 
 # re-exports from ScientificTypes
 export Scientific, Found, Unknown, Known, Finite, Infinite,

--- a/src/MLJModelInterface.jl
+++ b/src/MLJModelInterface.jl
@@ -38,7 +38,7 @@ export matrix, int, classes, decoder, table,
        nrows, selectrows, selectcols, select
 
 # equality
-export is_same_except
+export is_same_except, isrespresented
 
 # re-exports from ScientificTypes
 export Scientific, Found, Unknown, Known, Finite, Infinite,

--- a/src/equality.jl
+++ b/src/equality.jl
@@ -65,7 +65,7 @@ Base.in(x::MLJType, itr::Tuple) = special_in(x, itr)
 # A version of `in` that actually uses `==`:
 
 """
-    isrepresented(object::MLJBase.MLJType, objects)
+    isrepresented(object::MLJType, objects)
 
 Test if `object` has a representative in the iterable
 `objects`. This is a weaker requirement than `object in objects`.
@@ -74,8 +74,8 @@ Here we say `m1` *respresents* `m2` if `is_same_except(m1, m2)` is
 `true`.
 
 """
-isrepresented(object::MLJBase.MLJType, ::Nothing) = false
-function isrepresented(object::MLJBase.MLJType, itr)::Union{Bool,Missing}
+isrepresented(object::MLJType, ::Nothing) = false
+function isrepresented(object::MLJType, itr)::Union{Bool,Missing}
     for m in itr
         ismissing(m) && return missing
         is_same_except(m, object) && return true

--- a/src/equality.jl
+++ b/src/equality.jl
@@ -61,3 +61,24 @@ end
 Base.in(x::MLJType, itr::Set) = special_in(x, itr)
 Base.in(x::MLJType, itr::AbstractVector) = special_in(x, itr)
 Base.in(x::MLJType, itr::Tuple) = special_in(x, itr)
+
+# A version of `in` that actually uses `==`:
+
+"""
+    isrepresented(model::MLJBase.Model, models)
+
+Test if `model` has a representative in the iterable
+`models`. This is a weaker requirement than `model in models`.
+
+Here we say `m1` *respresents* `m2` if `is_same_except(m1, m2)` is
+`true`.
+
+"""
+isrepresented(model::MLJBase.Model, ::Nothing) = false
+function isrepresented(model::MLJBase.Model, models)::Union{Bool,Missing}
+    for m in models
+        ismissing(m) && return missing
+        is_same_except(m, model) && return true
+    end
+    return false
+end

--- a/src/equality.jl
+++ b/src/equality.jl
@@ -65,20 +65,20 @@ Base.in(x::MLJType, itr::Tuple) = special_in(x, itr)
 # A version of `in` that actually uses `==`:
 
 """
-    isrepresented(model::MLJBase.Model, models)
+    isrepresented(object::MLJBase.MLJType, objects)
 
-Test if `model` has a representative in the iterable
-`models`. This is a weaker requirement than `model in models`.
+Test if `object` has a representative in the iterable
+`objects`. This is a weaker requirement than `object in objects`.
 
 Here we say `m1` *respresents* `m2` if `is_same_except(m1, m2)` is
 `true`.
 
 """
-isrepresented(model::MLJBase.Model, ::Nothing) = false
-function isrepresented(model::MLJBase.Model, models)::Union{Bool,Missing}
-    for m in models
+isrepresented(object::MLJBase.MLJType, ::Nothing) = false
+function isrepresented(object::MLJBase.MLJType, itr)::Union{Bool,Missing}
+    for m in itr
         ismissing(m) && return missing
-        is_same_except(m, model) && return true
+        is_same_except(m, object) && return true
     end
     return false
 end

--- a/test/equality.jl
+++ b/test/equality.jl
@@ -97,5 +97,6 @@ end
     @test isrepresented(p, models)
 end
 
+end
 
 true

--- a/test/equality.jl
+++ b/test/equality.jl
@@ -94,9 +94,7 @@ end
     @test isrepresented(m, nothing) == false
     @test isrepresented(m, models)
     @test isrepresented(m2, models)
-    @test isrepresented(p, models)
-end
-
+    @test !isrepresented(p, models)
 end
 
 true

--- a/test/equality.jl
+++ b/test/equality.jl
@@ -84,4 +84,18 @@ end
 
 end
 
+@testset "isrepresented" begin
+    m = Foo(MersenneTwister(7), 1, 2)
+    m2 = Foo(MersenneTwister(8), 1, 2)
+    n = Foo(MersenneTwister(7), 3, 2)
+    p = Foo(MersenneTwister(9), 4, 5)
+    models = [m, n]
+
+    @test isrepresented(m, nothing) == false
+    @test isrepresented(m, models)
+    @test isrepresented(m2, models)
+    @test isrepresented(p, models)
+end
+
+
 true


### PR DESCRIPTION
```
isrepresented(model::MLJBase.Model, models)
```
Test if `model` has a representative in the iterable
`models`. This is a weaker requirement than `model in models`.

Here we say `m1` *respresents* `m2` if `is_same_except(m1, m2)` is
`true`.

"""
