### PR TITLE
Move parameter_inspection.jl from MLJBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModelInterface"
 uuid = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 authors = ["Thibaut Lienart and Anthony Blaom"]
-version = "0.2.1"
+version = "0.3.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -16,10 +16,9 @@ CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJScientificTypes = "2e2323e0-db8b-457b-ae0d-bdfb3bc63afd"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Tables", "Distances", "CategoricalArrays", "InteractiveUtils", "DataFrames", "MLJScientificTypes", "MLJBase"]
+test = ["Test", "Tables", "Distances", "CategoricalArrays", "InteractiveUtils", "DataFrames", "MLJScientificTypes"]

--- a/src/MLJModelInterface.jl
+++ b/src/MLJModelInterface.jl
@@ -16,6 +16,9 @@ export MLJType, Model, Supervised, Unsupervised,
        Probabilistic, Deterministic, Interval, Static,
        UnivariateFinite
 
+# parameter_inspection:
+export params
+
 # model constructor + metadata
 export @mlj_model, metadata_pkg, metadata_model
 
@@ -89,9 +92,9 @@ abstract type Static <: Unsupervised end
 # includes
 
 include("utils.jl")
+include("parameter_inspection.jl")
 include("data_utils.jl")
 include("metadata_utils.jl")
-
 include("model_traits.jl")
 include("model_def.jl")
 include("model_api.jl")

--- a/src/parameter_inspection.jl
+++ b/src/parameter_inspection.jl
@@ -6,9 +6,9 @@ istransparent(::MLJType) = true
 
 Recursively convert any transparent object `m` into a named tuple,
 keyed on the fields of `m`. An object is *transparent* if
-`MLJBase.istransparent(m) == true`. The named tuple is possibly nested
-because `params` is recursively applied to the field values, which
-themselves might be transparent.
+`MLJModelInterface.istransparent(m) == true`. The named tuple is
+possibly nested because `params` is recursively applied to the field
+values, which themselves might be transparent.
 
 Most objects of type `MLJType` are transparent.
 

--- a/src/parameter_inspection.jl
+++ b/src/parameter_inspection.jl
@@ -1,0 +1,33 @@
+istransparent(::Any) = false
+istransparent(::MLJType) = true
+
+"""
+    params(m::MLJType)
+
+Recursively convert any transparent object `m` into a named tuple,
+keyed on the fields of `m`. An object is *transparent* if
+`MLJBase.istransparent(m) == true`. The named tuple is possibly nested
+because `params` is recursively applied to the field values, which
+themselves might be transparent.
+
+Most objects of type `MLJType` are transparent.
+
+    julia> params(EnsembleModel(atom=ConstantClassifier()))
+    (atom = (target_type = Bool,),
+     weights = Float64[],
+     bagging_fraction = 0.8,
+     rng_seed = 0,
+     n = 100,
+     parallel = true,)
+
+"""
+params(m) = params(m, Val(istransparent(m)))
+params(m, ::Val{false}) = m
+function params(m, ::Val{true})
+    fields = fieldnames(typeof(m))
+    NamedTuple{fields}(Tuple([params(getfield(m, field)) for field in fields]))
+end
+
+
+
+

--- a/test/data_utils.jl
+++ b/test/data_utils.jl
@@ -70,7 +70,8 @@ end
     setfull()
     ary = rand(10, 3)
     @test M.schema(ary) === nothing
-    M.schema(::FI, ::Val{:table}, X; kw...) = MLJBase.schema(X; kw...) # this would be defined in MLJBase.jl
+    M.schema(::FI, ::Val{:table}, X; kw...) =
+        MLJScientificTypes.schema(X; kw...) 
     df = DataFrame(A = rand(10), B = categorical(rand('a':'c', 10)))
     sch = M.schema(df)
     @test sch.names == (:A, :B)

--- a/test/parameter_inspection.jl
+++ b/test/parameter_inspection.jl
@@ -1,0 +1,31 @@
+using Test
+using MLJModelInterface
+
+struct Opaque
+    a::Int
+end
+
+struct Transparent
+    A::Int
+    B::Opaque
+end
+
+MLJModelInterface.istransparent(::Transparent) = true
+
+struct Dummy <:MLJType
+    t::Transparent
+    o::Opaque
+    n::Integer
+end
+
+@testset "params method" begin
+
+    t= Transparent(6, Opaque(5))
+    m = Dummy(t, Opaque(7), 42)
+
+    @test params(m) == (t = (A = 6,
+                             B = Opaque(5)),
+                        o = Opaque(7),
+                        n = 42)
+end
+true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,9 +12,9 @@ setlight() = M.set_interface_mode(M.LightInterface())
 setfull()  = M.set_interface_mode(M.FullInterface())
 
 include("mode.jl")
+include("parameter_inspection.jl")
 include("data_utils.jl")
 include("metadata_utils.jl")
-
 include("model_def.jl")
 include("model_api.jl")
 include("model_traits.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using Test, MLJModelInterface
 using ScientificTypes, MLJScientificTypes
 using Tables, Distances, CategoricalArrays, InteractiveUtils
 import DataFrames: DataFrame
-import MLJBase
 
 const M  = MLJModelInterface
 const FI = M.FullInterface


### PR DESCRIPTION
Addresses the MLJModelInterface side of the migration in #28 .