### PR TITLE
For a 0.2.2 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
 
 [compat]
-ScientificTypes = "^0.7"
+ScientificTypes = "^0.7,^0.8"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModelInterface"
 uuid = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 authors = ["Thibaut Lienart and Anthony Blaom"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/data_utils.jl
+++ b/src/data_utils.jl
@@ -191,6 +191,7 @@ Return the number of rows for a table, abstract vector or matrix `X` $REQUIRE.
 nrows(X) = nrows(get_interface_mode(), vtrait(X), X)
 
 nrows(::Mode, ::Val{:other}, X::AbstractVecOrMat) = size(X, 1)
+nrows(::Mode, ::Val{:other}, X::Nothing) = 0
 
 nrows(::Mode, ::Val{:other}, X) =
     throw(ArgumentError("Function `nrows` only supports AbstractVector or " *

--- a/test/data_utils.jl
+++ b/test/data_utils.jl
@@ -97,6 +97,7 @@ end
     @test_throws ArgumentError nrows(X)
     X = (a=[4,2,1],b=[3,2,1])
     @test_throws M.InterfaceError nrows(X)
+    @test nrows(nothing) == 0
 end
 @testset "nrows-full" begin
     setfull()


### PR DESCRIPTION
- [x] Define `nrows(nothing) = 0`. Needed to allow `X = nothing` in supervised learners (for fitting distribution to some `y`).

- [x] Extend [compat] for ScientificTypes to "^0.7,^0.8"