### PR TITLE
For a 0.2.5 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModelInterface"
 uuid = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 authors = ["Thibaut Lienart and Anthony Blaom"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/data_utils.jl
+++ b/src/data_utils.jl
@@ -311,8 +311,10 @@ the provided dictionary, `prob_given_class` $REQUIRE. The dictionary keys must
 be of type `CategoricalElement` (see above) and the dictionary values specify
 the corresponding probabilities.
 """
-UnivariateFinite(d::AbstractDict) = UnivariateFinite(get_interface_mode(), d)
-UnivariateFinite(c::AbstractVector, p) =
-    UnivariateFinite(get_interface_mode(), c, p)
+UnivariateFinite(d::AbstractDict; kwargs...) =
+    UnivariateFinite(get_interface_mode(), d; kwargs...)
+UnivariateFinite(c::AbstractVector, p; kwargs...) =
+    UnivariateFinite(get_interface_mode(), c, p; kwargs...)
 
-UnivariateFinite(::LightInterface, a...) = errlight("UnivariateFinite")
+UnivariateFinite(::LightInterface, a...; kwargs...) =
+    errlight("UnivariateFinite")


### PR DESCRIPTION
Allow `UnivariateFinite` constructor to have kwargs