### PR TITLE
Add internal `istable` method

### DIFF
--- a/src/data_utils.jl
+++ b/src/data_utils.jl
@@ -140,6 +140,19 @@ schema(::LightInterface, ::Val{:other}, X; kw...) = errlight("schema")
 schema(::LightInterface, ::Val{:table}, X; kw...) = errlight("schema")
 
 # ------------------------------------------------------------------------
+# istable
+
+"""
+    istable(X)
+
+Return true if `X` is tabular.
+"""
+istable(X) = istable(get_interface_mode(), vtrait(X))
+istable(::Mode, ::Val{:other}) = false
+
+istable(::Mode, ::Val{:table}) = true
+
+# ------------------------------------------------------------------------
 # decoder
 
 """

--- a/src/data_utils.jl
+++ b/src/data_utils.jl
@@ -148,6 +148,7 @@ schema(::LightInterface, ::Val{:table}, X; kw...) = errlight("schema")
 Return true if `X` is tabular.
 """
 istable(X) = istable(get_interface_mode(), vtrait(X))
+
 istable(::Mode, ::Val{:other}) = false
 
 istable(::Mode, ::Val{:table}) = true

--- a/test/data_utils.jl
+++ b/test/data_utils.jl
@@ -80,6 +80,16 @@ end
     @test sch.scitypes[2] <: Multiclass
 end
 # ------------------------------------------------------------------------
+@testset "istable" begin
+    setlight()
+    X = rand(5)
+    @test !M.istable(X)
+    X = randn(5,5)
+    @test !M.istable(X)
+    X = DataFrame(A=rand(10))
+    @test M.istable(X)
+end
+# ------------------------------------------------------------------------
 @testset "decoder-light" begin
     setlight()
     x = 5


### PR DESCRIPTION
```julia
MMI.istable(DataFrame(A=rand(5))) # true
MMI.istable(rand(5)) # false
```

This is useful to avoid importing `Tables` in the MLJScikitLearn interface to detect if the target is a table or not (in the multi-target regression case). 