### PR TITLE
Add `JointProbabilistic` as a subtype of `Probabilistic`, and add generic function stub for `predict_joint`

### DIFF
--- a/src/MLJModelInterface.jl
+++ b/src/MLJModelInterface.jl
@@ -14,7 +14,8 @@ export LightInterface, FullInterface
 # MLJ model hierarchy
 export MLJType, Model, Supervised, Unsupervised,
        Probabilistic, Deterministic, Interval, Static,
-       UnivariateFinite
+       UnivariateFinite,
+       JointProbabilistic
 
 # parameter_inspection:
 export params
@@ -87,6 +88,8 @@ abstract type Deterministic <: Supervised end
 abstract type      Interval <: Supervised end
 
 abstract type Static <: Unsupervised end
+
+abstract type JointProbabilistic <: Probabilistic end
 
 # ------------------------------------------------------------------------
 # includes

--- a/src/model_api.jl
+++ b/src/model_api.jl
@@ -45,6 +45,13 @@ probabilistic supervised models may overload `predict_median`
 function predict_median end
 
 """
+`JointProbabilistic` supervised models MUST overload `predict_joint`.
+
+`Probabilistic` supervised models MAY overload `predict_joint`.
+"""
+function predict_joint end
+
+"""
 unsupervised methods must implement the `transform` operation
 """
 function transform end


### PR DESCRIPTION
Please see: https://github.com/alan-turing-institute/MLJ.jl/issues/642