### PR TITLE
Adds `supports_class_weights` as a trait

### DIFF
--- a/src/MLJModelInterface.jl
+++ b/src/MLJModelInterface.jl
@@ -31,8 +31,8 @@ export fit, update, update_data, transform, inverse_transform,
 export input_scitype, output_scitype, target_scitype,
        is_pure_julia, package_name, package_license,
        load_path, package_uuid, package_url,
-       is_wrapper, supports_weights, supports_online,
-       docstring, name, is_supervised,
+       is_wrapper, supports_weights, supports_class_weights,
+       supports_online, docstring, name, is_supervised,
        prediction_type, implemented_methods, hyperparameters,
        hyperparameter_types, hyperparameter_ranges
 

--- a/src/model_traits.jl
+++ b/src/model_traits.jl
@@ -5,8 +5,8 @@ const MODEL_TRAITS = [
     :input_scitype, :output_scitype, :target_scitype,
     :is_pure_julia, :package_name, :package_license,
     :load_path, :package_uuid, :package_url,
-    :is_wrapper, :supports_weights, :supports_online,
-    :docstring, :name, :is_supervised,
+    :is_wrapper, :supports_weights, :supports_class_weights,
+    :supports_online, :docstring, :name, :is_supervised,
     :prediction_type, :implemented_methods, :hyperparameters,
     :hyperparameter_types, :hyperparameter_ranges]
 
@@ -30,6 +30,7 @@ package_url(::Type)            = "unknown"
 is_wrapper(::Type)             = false
 supports_online(::Type)        = false
 supports_weights(::Type)       = false  # used for measures too
+supports_class_weights(::Type) = false  # used for measures too
 hyperparameter_ranges(T::Type) = Tuple(fill(nothing, length(fieldnames(T))))
 docstring(M::Type)             = string(M)
 docstring(M::Type{<:MLJType})  = name(M)

--- a/test/model_traits.jl
+++ b/test/model_traits.jl
@@ -36,9 +36,10 @@ bar(::P1) = nothing
     @test package_uuid(ms)    == "unknown"
     @test package_url(ms)     == "unknown"
 
-    @test is_wrapper(ms)       == false
-    @test supports_online(ms)  == false
-    @test supports_weights(ms) == false
+    @test is_wrapper(ms)             == false
+    @test supports_online(ms)        == false
+    @test supports_weights(ms)       == false
+    @test supports_class_weights(ms) == false
 
     @test hyperparameter_ranges(md) == (nothing,)
 


### PR DESCRIPTION
In wake of [list of models](https://github.com/alan-turing-institute/MLJ.jl/issues/327) that support class weights this trait will be eventually added to  `model_traits.jl`

**This adds `:supports_class_weight`, a test for the same and exports it.**

I'm adding it now so that ongoing [modification](https://github.com/alan-turing-institute/MLJBase.jl/pull/464) to `resampling.jl`, doesn't have to be cleaned up again.