### PR TITLE
Add facility for adding a data front-end to a model implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModelInterface"
 uuid = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 authors = ["Thibaut Lienart and Anthony Blaom"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/MLJModelInterface.jl
+++ b/src/MLJModelInterface.jl
@@ -25,7 +25,7 @@ export @mlj_model, metadata_pkg, metadata_model
 # model api
 export fit, update, update_data, transform, inverse_transform,
     fitted_params, predict, predict_mode, predict_mean, predict_median,
-    predict_joint, evaluate, clean!
+    predict_joint, evaluate, clean!, reformat
 
 # model traits
 export input_scitype, output_scitype, target_scitype,

--- a/src/model_api.jl
+++ b/src/model_api.jl
@@ -40,8 +40,8 @@ make use of more efficient row subsampling, which is then based on the
 model-specific representation of data, rather than the
 user-representation. When `reformat` is overloaded,
 `selectrows(::Model, ...)` must be as well (see
-[`selectrows](@ref)). Furthermore, the model `fit` method(s), and
-operations such as `predict` and `transform`, must be refactored to
+[`selectrows`](@ref)). Furthermore, the model `fit` method(s), and
+operations, such as `predict` and `transform`, must be refactored to
 act on the model-specific representions of the data.
 
 To implement the `reformat` data front-end for a model, refer to

--- a/src/model_api.jl
+++ b/src/model_api.jl
@@ -34,91 +34,20 @@ function update_data end
 
 Models optionally overload `reformat` to define transformations of
 user-supplied data into some model-specific representation (e.g., from
-a table to a matrix). Computational overheads associated with multiple
-`fit!`/`predict`/`transform` calls are then avoided, when memory
-resources allow. The fallback returns `args` (no transformation).
+a table to a matrix). When implemented, the MLJ user can avoid
+repeating such transformations unnecessarily, and can additionally
+make use of more efficient row subsampling, which is then based on the
+model-specific representation of data, rather than the
+user-representation. When `reformat` is overloaded,
+`selectrows(::Model, ...)` must be as well (see
+[`selectrows](@ref)). Furthermore, the model `fit` method(s), and
+operations such as `predict` and `transform`, must be refactored to
+act on the model-specific representions of the data.
 
-Here "user-supplied data" is what the MLJ user supplies when
-constructing a machine, as in `machine(models, args...)`, which
-coincides with the arguments expected by `fit(model, verbosity,
-args...)` when `reformat` is not overloaded.
+To implement the `reformat` data front-end for a model, refer to
+"Implementing a data front-end" in the [MLJ
+manual](https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/).
 
-Implementing a `reformat` data front-end is permitted for any `Model`
-subtype, except for subtypes of `Static`. Here is a complete list of
-responsibilities for such an implementation, for some
-`model::SomeModelType`:
-
-- A `reformat(model::SomeModelType, args...) -> data` method must be
-  implemented for each form of `args...` appearing in a valid machine
-  construction `machine(model, args...)` (there will be one for each
-  possible signature of `fit(::SomeModelType, ...)`).
-
-- Additionally, if not included above, there must be a single argument
-  form of reformat, `reformat(model::SommeModelType, arg) -> (data,)`,
-  serving as a data front-end for operations like `predict`. It must
-  always hold that `reformat(model, args...)[1] = reformat(model,
-  args[1])`.
-
-**Warning.** `reformat(model::SomeModelType, args...)` must always
-  return a tuple of the same length as `args`, even if this is one.
-
-- `fit(model::SomeModelType, verbosity, data...)` should be
-  implemented as if `data` is the output of `reformat(model,
-  args...)`, where `args` is the data an MLJ user has bound to `model`
-  in some machine. The same applies to any overloading of `update`.
-
-- Each implemented operation, such as `predict` and `transform` - but
-  excluding `inverse_transform` - must be defined as if its data
-  arguments are `reformat`ed versions of user-supplied data. For
-  example, in the supervised case, `data_new` in
-  `predict(model::SomeModelType, fitresult, data_new)` is
-  `reformat(model, Xnew)`, where `Xnew is the data provided by the MLJ
-  user in a call `predict(mach, Xnew)` (`mach.model == model`).
-
-- To specify how the model-specific representation of data is to be
-  resampled, implement `selectrows(model::SomeModelType, I, data...)
-  -> resampled_data` for each overloading of `reformat(model::SomeModel,
-  args...) -> data` above. Here `I` is an arbitrary abstract integer
-  vector or `:` (type `Colon`).
-
-**Warning.** `selectrows(model::SomeModelType, I, args...)` must always
-return a tuple of the same length as `args`, even if this is one.
-
-The fallback for `selectrows` is described at [`selectrows`](@ref).
-
-
-### Example
-
-Suppose a supervised model type `SomeSupervised` supports sample
-weights, leading to two different `fit` signatures:
-
-    fit(model::SomeSupervised, verbosity, X, y)
-    fit(model::SomeSupervised, verbosity, X, y, w)
-
-    predict(model::SomeSupervised, fitresult, Xnew)
-
-Without a data front-end implemented, suppose `X` is expected to be a
-table and `y` a vector, but suppose the core algorithm always converts
-`X` to a matrix with features as rows (features corresponding to
-columns in the table).  Then a new data-front end might look like
-this:
-
-    constant MMI = MLJModelInterface
-
-    # for fit:
-    MMI.reformat(::SomeSupervised, X, y) = (MMI.matrix(X, transpose=true), y)
-    MMI.reformat(::SomeSupervised, X, y, w) = (MMI.matrix(X, transpose=true), y, w)
-    MMI.selectrows(::SomeSupervised, I, Xmatrix, y) =
-        (view(Xmatrix, :, I), view(y, I))
-    MMI.selectrows(::SomeSupervised, I, Xmatrix, y, w) =
-        (view(Xmatrix, :, I), view(y, I), view(w, I))
-
-    # for predict:
-    MMI.reformat(::SomeSupervised, X) = (MMI.matrix(X, transpose=true),)
-    MMI.selectrows(::SomeSupervised, I, Xmatrix) = view(Xmatrix, I)
-
-With these additions, `fit` and `predict` are refactored, so that `X`
-and `Xnew` represent matrices with features as rows.
 
 """
 reformat(model::Model, args...) = args

--- a/src/model_api.jl
+++ b/src/model_api.jl
@@ -1,31 +1,102 @@
 """
-every model interface must implement a `fit` method of the form
-`fit(model, verb::Integer, training_args...) -> fitresult, cache, report`
+    fit(model, verbosity, data...) -> fitresult, cache, report
+
+All models must implement a `fit` method. Here `data` is the
+output of `reformat` on user-provided data, or some some resampling
+thereof. The fallback of `reformat` returns the user-provided data
+(eg, a table).
+
 """
 function fit end
 
 # fallback for static transformations
-fit(::Static, ::Integer, a...) = (nothing, nothing, nothing)
+fit(::Static, ::Integer, data...) = (nothing, nothing, nothing)
 
 # fallbacks for supervised models that don't support sample weights:
-fit(m::Supervised, verb::Integer, X, y, w) = fit(m, verb, X, y)
-
-# this operation can be optionally overloaded to provide access to
-# fitted parameters (eg, coeficients of linear model):
-fitted_params(::Model, fitres) = (fitresult=fitres,)
+fit(m::Supervised, verbosity, X, y, w) = fit(m, verbosity, X, y)
 
 """
-each model interface may overload the `update` refitting method
-"""
-update(m::Model, verb::Integer, fitres, cache, a...) = fit(m, verb, a...)
+    update(model, verbosity, fitresult, cache, data...)
+
+Models may optionally implement an `update` method. The fallback calls
+`fit`.
 
 """
-each model interface may overload the `update_data` refitting method for online learning
-"""
+update(m::Model, verbosity, fitresult, cache, data...) =
+    fit(m, verbosity, data...)
+
+# to support online learning in the future:
+# https://github.com/alan-turing-institute/MLJ.jl/issues/60 :
 function update_data end
 
 """
-supervised methods must implement the `predict` operation
+    MLJModelInterface.reformat(model, args...) -> data
+
+Models optionally overload `reformat` to define transformations of
+user-supplied training data `args` into some model-specific
+representation `data` (e.g., from a table to a matrix). The fallback
+returns `args` (no transformation).
+
+If `mach` is a machine with `mach.model == model` then calling `fit!(mach)`
+will either call
+
+    fit(model, verbosity, data...)
+
+or
+
+    update(model, verbosity, data...)
+
+where `data = reformat(model, mach.args...)`. This means that
+overloading `reformat` alters the form of the arguments expected by
+`fit` and `update`.
+
+If, instead, one calls `fit!(mach, rows=I)`, then `data` in the above
+`fit`/`update` calls is replaced with `selectrows(model, I,
+data...)`. So overloading `reformat` generally requires overloading of
+`selectrows` also, to specify how the model-specific representation of
+training data is resampled.
+
+Note `data` is always a tuple, but it needn't have the same length as
+`args`.
+
+"""
+reformat(model::Model, args...) = args
+
+"""
+    selectrows(::Model, I, data...) -> sampled_data
+
+Models optionally overload `selectrows` for efficient resampling of
+training data. Here `data` is the ouput of calling `reformat` on
+user-provided data.  The fallback assumes `data` is a tuple and calls
+`selectrows(X, I)` for each `X` in `data`, returning the results in a
+new tuple of the same length. This call makes sense when `X` is a
+table, abstract vector or abstract matrix. In the last two cases, a
+new object and *not* a view is returned.
+
+"""
+selectrows(::Model, I, data...) = map(X -> selectrows(X, I), data)
+
+# this operation can be optionally overloaded to provide access to
+# fitted parameters (eg, coeficients of linear model):
+"""
+   fitted_params(model, fitresult) -> human_readable_fitresult # named_tuple
+
+Models may overload `fitted_params`. The fallback returns
+`(fitresult=fitresult,)`.
+
+Other training-related outcomes should be returned in the `report`
+part of the tuple returned by `fit`.
+
+"""
+fitted_params(::Model, fitresult) = (fitresult=fitresult,)
+
+"""
+
+    predict(model, fitresult, new_data...)
+
+`Supervised` models must implement the `predict` operation. Here
+`new_data` is the output of `reformat` called on user-specified data.
+
 """
 function predict end
 

--- a/test/model_api.jl
+++ b/test/model_api.jl
@@ -7,6 +7,12 @@ end
 
 mutable struct APIx1 <: Static end
 
+@testset "selectrows(model, data...)" begin
+    X = (x1 = [2, 4, 6],)
+    y = [10.0, 20.0, 30.0]
+    @test selectrows(APIx0(), 2:3, X, y) == ((x1 = [4, 6],), [20.0, 30.0])
+end
+
 @testset "fit-x" begin
     m0 = APIx0(f0=1)
     m1 = APIx0b(f0=3)


### PR DESCRIPTION
A PR to support https://github.com/alan-turing-institute/MLJBase.jl/pull/492.

Adds:

- `reformat` method/fallback
-  `selectrows(model::Model, I, args...) -> data` fallback

From the new doc-strings (**edited**):

---

    MLJModelInterface.reformat(model, args...) -> data

Models optionally overload `reformat` to define transformations of
user-supplied data into some model-specific representation (e.g., from
a table to a matrix). When implemented, the MLJ user can avoid
repeating such transformations unnecessarily, and can additionally
make use of more efficient row subsampling, which is then based on the
model-specific representation of data, rather than the
user-representation. When `reformat` is overloaded,
`selectrows(::Model, ...)` must be as well (see
[`selectrows`](@ref)). Furthermore, the model `fit` method(s), and
operations, such as `predict` and `transform`, must be refactored to
act on the model-specific representions of the data.

To implement the `reformat` data front-end for a model, refer to
"Implementing a data front-end" in the [MLJ
manual](https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/).

    selectrows(::Model, I, data...) -> sampled_data

A model overloads `selectrows` whenever it buys into the optional
`reformat` front-end for data preprocessing. See [`reformat`](@ref)
for details. The fallback assumes `data` is a tuple and calls
`selectrows(X, I)` for each `X` in `data`, returning the results in a
new tuple of the same length. This call makes sense when `X` is a
table, abstract vector or abstract matrix. In the last two cases, a
new object and *not* a view is returned.



