### PR TITLE
suggested fix for typename issue in 1.6+

### DIFF
--- a/src/model_traits.jl
+++ b/src/model_traits.jl
@@ -36,8 +36,10 @@ docstring(M::Type{<:MLJType})  = name(M)
 docstring(M::Type{<:Model})    = "$(name(M)) from $(package_name(M)).jl.\n" *
                                  "[Documentation]($(package_url(M)))."
 # "derived" traits:
-name(M::Type)            = string(M)
-name(M::Type{<:MLJType}) = split(string(coretype(M)), '.')[end] |> String
+typename(s)              = replace(s, r"typename\((.*?)\)" => s"\1")
+name(M::Type)            = string(M) |> typename
+name(M::Type{<:MLJType}) = split(string(coretype(M)), '.')[end] |> String |> typename
+
 
 is_supervised(::Type)                    = false
 is_supervised(::Type{<:Supervised})      = true

--- a/test/model_traits.jl
+++ b/test/model_traits.jl
@@ -72,5 +72,9 @@ struct FooMeasure <: MLJType end
     @test name(Float64) == "Float64"
 
     df = DataFrame(a=randn(2), b=randn(2))
-    @test string(M.coretype(typeof(df))) == "DataFrame"
+    if VERSION < v"1.6-"
+        @test string(M.coretype(typeof(df))) == "DataFrame"
+    else
+        @test string(M.coretype(typeof(df))) == "typename(DataFrame)"
+    end
 end

--- a/test/model_traits.jl
+++ b/test/model_traits.jl
@@ -72,9 +72,10 @@ struct FooMeasure <: MLJType end
     @test name(Float64) == "Float64"
 
     df = DataFrame(a=randn(2), b=randn(2))
-    if VERSION < v"1.6-"
+    @static if VERSION < v"1.6-"
         @test string(M.coretype(typeof(df))) == "DataFrame"
     else
         @test string(M.coretype(typeof(df))) == "typename(DataFrame)"
     end
+    @test M.name(typeof(df)) == "DataFrame"
 end


### PR DESCRIPTION
This fixes the issue with `typename` that breaks a number of MLJ* package tests with the upcoming release  (https://discourse.julialang.org/t/analysis-of-pkgeval-results-for-upcoming-1-6/53194) 

In short `"$(M)"` for `M::Type` seem to have been `TheType` before and now `typename(TheType)`. I've consequently added a simple `replace` to remove this. I also added a version condition to a test on `coretype` (which, incidentally, illustrates quite well what the problem was).

I tested this with Julia 1.5.3, Julia 1.6-beta and nightly.