### PR TITLE
implement non-erroring fallback for selectrows to address #77

### DIFF
--- a/src/data_utils.jl
+++ b/src/data_utils.jl
@@ -239,10 +239,14 @@ Select single or multiple rows from a table, abstract vector or matrix
 preferred sink type of `typeof(X)`, even if only a single row is
 selected.
 
+If the object is neither a table, abstract vector or matrix, `X` is
+returned and `r` is ignored.
+
 """
 selectrows(X, r) = selectrows(get_interface_mode(), vtrait(X), X, r)
 
-selectrows(::Mode, ::Val{:other}, ::Nothing, r) = nothing
+# fall-back is to return object, ignoring vector of row indices, `r`:
+selectrows(::Mode, ::Val{:other}, X::Any, r) = X
 
 selectrows(::Mode, ::Val{:other}, X::AbstractVector, r)          = X[r]
 selectrows(::Mode, ::Val{:other}, X::AbstractVector, r::Integer) = X[r:r]
@@ -251,10 +255,6 @@ selectrows(::Mode, ::Val{:other}, X::AbstractVector, ::Colon)    = X
 selectrows(::Mode, ::Val{:other}, X::AbstractMatrix, r)          = X[r, :]
 selectrows(::Mode, ::Val{:other}, X::AbstractMatrix, r::Integer) = X[r:r, :]
 selectrows(::Mode, ::Val{:other}, X::AbstractMatrix, ::Colon)    = X
-
-selectrows(::Mode, ::Val{:other}, X, r) =
-    throw(ArgumentError("Function `selectrows` only supports AbstractVector " *
-                        "or AbstractMatrix or containers implementing the " * "Tables interface."))
 
 selectrows(::LightInterface, ::Val{:table}, X, r; kw...) =
     errlight("selectrows")

--- a/test/data_utils.jl
+++ b/test/data_utils.jl
@@ -141,6 +141,8 @@ end
 # ------------------------------------------------------------------------
 @testset "select-light" begin
     setlight()
+
+    # test fallback
     X = nothing
     @test selectrows(X, 1) === nothing
     @test selectcols(X, 1) === nothing
@@ -173,12 +175,20 @@ end
 
     # something else
     X = (1,2,3)
-    @test_throws ArgumentError selectrows(X, 1)
+    selectrows(X, 1) == X
     @test_throws ArgumentError selectcols(X, 1)
     @test_throws ArgumentError select(X, 1, 1)
 end
 @testset "select-full" begin
     setfull()
+
+    # test fallback
+    X = nothing
+    @test selectrows(X, 1) === nothing
+    @test selectcols(X, 1) === nothing
+    @test select(X, 1, 2)  === nothing
+
+    # implement some behaviour:
     M.selectrows(::FI, ::Val{:table}, X, ::Colon) = X
     M.selectcols(::FI, ::Val{:table}, X, ::Colon) = X
     function M.selectrows(::FI, ::Val{:table}, X, r)


### PR DESCRIPTION
This is a PR to address #77. 

Currently, if `selectrows(X, r)` receives an object `X` that is neither a matrix, vector nor table, it throws an error. Now it simply returns `X` and ignores `r`. 

`selectcols(X, c)` continues to throw an error if `X` is neither matrix nor table; perhaps for consistency it should return `X` instead?