### PR TITLE
For a 0.4.0 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModelInterface"
 uuid = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 authors = ["Thibaut Lienart and Anthony Blaom"]
-version = "0.3.9"
+version = "0.4.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/data_utils.jl
+++ b/src/data_utils.jl
@@ -239,10 +239,14 @@ Select single or multiple rows from a table, abstract vector or matrix
 preferred sink type of `typeof(X)`, even if only a single row is
 selected.
 
+If the object is neither a table, abstract vector or matrix, `X` is
+returned and `r` is ignored.
+
 """
 selectrows(X, r) = selectrows(get_interface_mode(), vtrait(X), X, r)
 
-selectrows(::Mode, ::Val{:other}, ::Nothing, r) = nothing
+# fall-back is to return object, ignoring vector of row indices, `r`:
+selectrows(::Mode, ::Val{:other}, X::Any, r) = X
 
 selectrows(::Mode, ::Val{:other}, X::AbstractVector, r)          = X[r]
 selectrows(::Mode, ::Val{:other}, X::AbstractVector, r::Integer) = X[r:r]
@@ -251,10 +255,6 @@ selectrows(::Mode, ::Val{:other}, X::AbstractVector, ::Colon)    = X
 selectrows(::Mode, ::Val{:other}, X::AbstractMatrix, r)          = X[r, :]
 selectrows(::Mode, ::Val{:other}, X::AbstractMatrix, r::Integer) = X[r:r, :]
 selectrows(::Mode, ::Val{:other}, X::AbstractMatrix, ::Colon)    = X
-
-selectrows(::Mode, ::Val{:other}, X, r) =
-    throw(ArgumentError("Function `selectrows` only supports AbstractVector " *
-                        "or AbstractMatrix or containers implementing the " * "Tables interface."))
 
 selectrows(::LightInterface, ::Val{:table}, X, r; kw...) =
     errlight("selectrows")

--- a/test/data_utils.jl
+++ b/test/data_utils.jl
@@ -141,6 +141,8 @@ end
 # ------------------------------------------------------------------------
 @testset "select-light" begin
     setlight()
+
+    # test fallback
     X = nothing
     @test selectrows(X, 1) === nothing
     @test selectcols(X, 1) === nothing
@@ -173,12 +175,20 @@ end
 
     # something else
     X = (1,2,3)
-    @test_throws ArgumentError selectrows(X, 1)
+    selectrows(X, 1) == X
     @test_throws ArgumentError selectcols(X, 1)
     @test_throws ArgumentError select(X, 1, 1)
 end
 @testset "select-full" begin
     setfull()
+
+    # test fallback
+    X = nothing
+    @test selectrows(X, 1) === nothing
+    @test selectcols(X, 1) === nothing
+    @test select(X, 1, 2)  === nothing
+
+    # implement some behaviour:
     M.selectrows(::FI, ::Val{:table}, X, ::Colon) = X
     M.selectcols(::FI, ::Val{:table}, X, ::Colon) = X
     function M.selectrows(::FI, ::Val{:table}, X, r)


### PR DESCRIPTION
- (**breaking**) Import model traits from new StatisticalTraits.jl package and add `supports_class_weights`

- (**bug fix**) Change fallback of `selectrows(X, rows)` to return `X` if `X` is not one of these: table, matrix, vector (#84)