### PR TITLE
Add list of model subtypes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModelInterface"
 uuid = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 authors = ["Thibaut Lienart and Anthony Blaom"]
-version = "1.1.2"
+version = "1.1.3"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/MLJModelInterface.jl
+++ b/src/MLJModelInterface.jl
@@ -26,6 +26,15 @@ const MODEL_TRAITS = [
     :supports_training_losses,
     :deep_properties]
 
+const ABSTRACT_MODEL_SUBTYPES =
+    [:Supervised,
+     :Unsupervised,
+     :Probabilistic,
+     :Deterministic,
+     :Interval,
+     :JointProbabilistic,
+     :Static]
+
 # ------------------------------------------------------------------------
 # Dependencies
 using ScientificTypesBase
@@ -38,10 +47,13 @@ using Random
 # mode
 export LightInterface, FullInterface
 
-# MLJ model hierarchy
-export MLJType, Model, Supervised, Unsupervised,
-       Probabilistic, JointProbabilistic, Deterministic, Interval, Static,
-       UnivariateFinite
+# model types
+export MLJType, Model
+for T in ABSTRACT_MODEL_SUBTYPES
+    @eval(export $T)
+end
+
+export UnivariateFinite
 
 # parameter_inspection:
 export params
@@ -95,12 +107,11 @@ struct InterfaceError <: Exception
     m::String
 end
 
-# ------------------------------------------------------------------------
-# Model types
-
 abstract type MLJType end
-
 abstract type Model   <: MLJType end
+
+# ------------------------------------------------------------------------
+# Model subtypes
 
 abstract type   Supervised <: Model end
 abstract type Unsupervised <: Model end


### PR DESCRIPTION
This PR lists all the abstract `Model` subtypes into a constant `ABSTRACT_MODEL_SUBTYPES` for automated export and easier downstream maintenance (eg, extension of types by surrogate/composite versions in MLJBase).