### PR TITLE
modify vtrait internal method

### DIFF
--- a/src/MLJModelInterface.jl
+++ b/src/MLJModelInterface.jl
@@ -1,7 +1,7 @@
 module MLJModelInterface
 
-const MODEL_TRAITS =
-    [:input_scitype,
+const MODEL_TRAITS = [
+    :input_scitype,
     :output_scitype,
     :target_scitype,
     :fit_data_scitype,
@@ -29,25 +29,27 @@ const MODEL_TRAITS =
     :hyperparameter_ranges,
     :iteration_parameter,
     :supports_training_losses,
-    :deep_properties]
+    :deep_properties
+]
 
-const ABSTRACT_MODEL_SUBTYPES =
-    [:Supervised,
-     :Unsupervised,
-     :Probabilistic,
-     :Deterministic,
-     :Interval,
-     :JointProbabilistic,
-     :Static,
-     :Annotator,
-     :SupervisedAnnotator,
-     :UnsupervisedAnnotator,
-     :SupervisedDetector,
-     :UnsupervisedDetector,
-     :ProbabilisticSupervisedDetector,
-     :ProbabilisticUnsupervisedDetector,
-     :DeterministicSupervisedDetector,
-     :DeterministicUnsupervisedDetector]
+const ABSTRACT_MODEL_SUBTYPES = [
+    :Supervised,
+    :Unsupervised,
+    :Probabilistic,
+    :Deterministic,
+    :Interval,
+    :JointProbabilistic,
+    :Static,
+    :Annotator,
+    :SupervisedAnnotator,
+    :UnsupervisedAnnotator,
+    :SupervisedDetector,
+    :UnsupervisedDetector,
+    :ProbabilisticSupervisedDetector,
+    :ProbabilisticUnsupervisedDetector,
+    :DeterministicSupervisedDetector,
+    :DeterministicUnsupervisedDetector
+]
 
 
 # ------------------------------------------------------------------------
@@ -55,6 +57,8 @@ const ABSTRACT_MODEL_SUBTYPES =
 using ScientificTypesBase
 using StatisticalTraits
 using Random
+
+import StatisticalTraits: info
 
 # ------------------------------------------------------------------------
 # exports
@@ -64,6 +68,7 @@ export LightInterface, FullInterface
 
 # model types
 export MLJType, Model
+
 for T in ABSTRACT_MODEL_SUBTYPES
     @eval(export $T)
 end
@@ -89,29 +94,29 @@ end
 
 # data operations
 export matrix, int, classes, decoder, table,
-       nrows, selectrows, selectcols, select
+    nrows, selectrows, selectcols, select, info
 
 # equality
 export is_same_except, isrepresented
 
 # re-exports from ScientificTypesBase
 export Scientific, Found, Unknown, Known, Finite, Infinite,
-       OrderedFactor, Multiclass, Count, Continuous, Textual,
-       Binary, ColorImage, GrayImage, Image, Table
-export scitype, scitype_union, elscitype, nonmissing, trait, info
+    OrderedFactor, Multiclass, Count, Continuous, Textual,
+    Binary, ColorImage, GrayImage, Image, Table, nonmissing
 
 # ------------------------------------------------------------------------
 # To be extended
 
 import Base.==
 import Base: in, isequal
-#
+
 # ------------------------------------------------------------------------
 # Mode trick
 
-abstract type Mode end
-struct LightInterface <: Mode end
-struct FullInterface  <: Mode end
+struct LightInterface end
+struct FullInterface end
+
+const Mode = Union{LightInterface, FullInterface}
 
 const INTERFACE_MODE = Ref{Mode}(LightInterface())
 
@@ -124,33 +129,33 @@ struct InterfaceError <: Exception
 end
 
 abstract type MLJType end
-abstract type Model   <: MLJType end
+abstract type Model <: MLJType end
 
 # ------------------------------------------------------------------------
 # Model subtypes
 
-abstract type          Supervised <: Model end
-abstract type        Unsupervised <: Model end
-abstract type           Annotator <: Model end
+abstract type Supervised <: Model end
+abstract type Unsupervised <: Model end
+abstract type Annotator <: Model end
 
 abstract type Probabilistic <: Supervised end
 abstract type Deterministic <: Supervised end
-abstract type      Interval <: Supervised end
+abstract type Interval <: Supervised end
 
 abstract type JointProbabilistic <: Probabilistic end
 
-abstract type Static                <: Unsupervised end
+abstract type Static <: Unsupervised end
 
-abstract type SupervisedAnnotator   <: Annotator end
+abstract type SupervisedAnnotator <: Annotator end
 abstract type UnsupervisedAnnotator <: Annotator end
 
 abstract type UnsupervisedDetector <: UnsupervisedAnnotator end
-abstract type SupervisedDetector   <: SupervisedAnnotator end
+abstract type SupervisedDetector <: SupervisedAnnotator end
 
-abstract type ProbabilisticSupervisedDetector   <: SupervisedDetector end
+abstract type ProbabilisticSupervisedDetector <: SupervisedDetector end
 abstract type ProbabilisticUnsupervisedDetector <: UnsupervisedDetector end
 
-abstract type DeterministicSupervisedDetector   <: SupervisedDetector end
+abstract type DeterministicSupervisedDetector <: SupervisedDetector end
 abstract type DeterministicUnsupervisedDetector <: UnsupervisedDetector end
 
 # ------------------------------------------------------------------------
@@ -163,6 +168,5 @@ include("model_traits.jl")
 include("model_def.jl")
 include("model_api.jl")
 include("equality.jl")
-
 
 end # module

--- a/src/data_utils.jl
+++ b/src/data_utils.jl
@@ -257,7 +257,7 @@ table(::LightInterface, X; kw...) = errlight("table")
 """
     nrows(X)
 
-return the number of rows for a table, abstractvector or abtractmatrix, `X`.
+Return the number of rows for a table, `AbstractVector` or `AbtractMatrix`, `X`.
 """
 function nrows(X)
     m = get_interface_mode()

--- a/src/equality.jl
+++ b/src/equality.jl
@@ -11,7 +11,7 @@ function _equal_to_depth_one(x1, x2)
     names = propertynames(x1)
     names === propertynames(x2) || return false
     for name in names
-            getproperty(x1, name) == getproperty(x2, name) || return false
+        getproperty(x1, name) == getproperty(x2, name) || return false
     end
     return true
 end
@@ -39,28 +39,34 @@ See also [`is_same_except`](@ref)
 Consider an `MLJType` subtype `Foo`, with a single field of
 type `Bar` which is *not* a subtype of `MLJType`:
 
-    mutable struct Bar
-        x::Int
-    end
+```julia
+mutable struct Bar
+    x::Int
+end
 
-    mutable struct Foo <: MLJType
-        bar::Bar
-    end
+mutable struct Foo <: MLJType
+    bar::Bar
+end
+```
 
 Then the mutability of `Foo` implies `Foo(1) != Foo(1)` and so, by the
 definition `==` for `MLJType` objects (see [`is_same_except`](@ref))
 we have
 
-    Bar(Foo(1)) != Bar(Foo(1))
+```julia
+Bar(Foo(1)) != Bar(Foo(1))
+```
 
 However after the declaration
 
-    MLJModelInterface.deep_properties(::Type{<:Foo}) = (:bar,)
-
+```julia
+MLJModelInterface.deep_properties(::Type{<:Foo}) = (:bar,)
+```
 We have
 
-    Bar(Foo(1)) == Bar(Foo(1))
-
+```julia
+Bar(Foo(1)) == Bar(Foo(1))
+```
 """
 StatisticalTraits.deep_properties
 
@@ -94,9 +100,11 @@ If `m1` or `m2` are not `MLJType` objects, then return `==(m1, m2)`.
 
 """
 is_same_except(x1, x2) = ==(x1, x2)
+
 function is_same_except(m1::M1,
-                        m2::M2,
-                        exceptions::Symbol...) where {M1<:MLJType,M2<:MLJType}
+    m2::M2,
+    exceptions::Symbol...
+) where {M1<:MLJType, M2<:MLJType}
     typeof(m1) === typeof(m2) || return false
     names = propertynames(m1)
     propertynames(m2) === names || return false
@@ -107,13 +115,19 @@ function is_same_except(m1::M1,
                !_isdefined(m2, name) || return false
             elseif _isdefined(m2, name)
                 if name in deep_properties(M1)
-                    _equal_to_depth_one(getproperty(m1,name),
-                                        getproperty(m2, name)) || return false
+                    _equal_to_depth_one(
+                        getproperty(m1,name),
+                        getproperty(m2, name)
+                    ) || return false
                 else
-                    (is_same_except(getproperty(m1, name),
-                                    getproperty(m2, name)) ||
-                     getproperty(m1, name) isa AbstractRNG ||
-                     getproperty(m2, name) isa AbstractRNG) || return false
+                    (
+                        is_same_except(
+                            getproperty(m1, name),
+                            getproperty(m2, name)
+                        ) || 
+                        getproperty(m1, name) isa AbstractRNG ||
+                        getproperty(m2, name) isa AbstractRNG
+                    ) || return false
                 end
             else
                 return false
@@ -123,7 +137,7 @@ function is_same_except(m1::M1,
     return true
 end
 
-==(m1::M1, m2::M2) where {M1<:MLJType,M2<:MLJType} = is_same_except(m1, m2)
+==(m1::M1, m2::M2) where {M1<:MLJType, M2<:MLJType} = is_same_except(m1, m2)
 
 # for using `replace` or `replace!` on collections of MLJType objects
 # (eg, Model objects in a learning network) we need a stricter
@@ -139,6 +153,7 @@ function special_in(x, itr)::Union{Bool,Missing}
     end
     return false
 end
+
 Base.in(x::MLJType, itr::Set) = special_in(x, itr)
 Base.in(x::MLJType, itr::AbstractVector) = special_in(x, itr)
 Base.in(x::MLJType, itr::Tuple) = special_in(x, itr)
@@ -156,6 +171,7 @@ Here we say `m1` *respresents* `m2` if `is_same_except(m1, m2)` is
 
 """
 isrepresented(object::MLJType, ::Nothing) = false
+
 function isrepresented(object::MLJType, itr)::Union{Bool,Missing}
     for m in itr
         ismissing(m) && return missing

--- a/src/metadata_utils.jl
+++ b/src/metadata_utils.jl
@@ -9,11 +9,11 @@ function docstring_ext(T; descr::String="")
     package_url  = MLJModelInterface.package_url(T)
     model_name   = MLJModelInterface.name(T)
     # the message to return
-    message      = "$descr"
-    message     *= "\n→ based on [$package_name]($package_url)."
-    message     *= "\n→ do `@load $model_name pkg=\"$package_name\"` to " *
-                   "use the model."
-    message     *= "\n→ do `?$model_name` for documentation."
+    message = "$descr"
+    message *= "\n→ based on [$package_name]($package_url)."
+    message *= "\n→ do `@load $model_name pkg=\"$package_name\"` to " *
+        "use the model."
+    message *= "\n→ do `?$model_name` for documentation."
 end
 
 """
@@ -34,7 +34,7 @@ a series of models.
 
 ## Example
 
-```
+```julia
 metadata_pkg.((KNNRegressor, KNNClassifier),
     package_name="NearestNeighbors",
     package_uuid="b8a86587-4115-5ab1-83bc-aa920d37bbce",
@@ -44,31 +44,30 @@ metadata_pkg.((KNNRegressor, KNNClassifier),
     is_wrapper=false)
 ```
 """
-function metadata_pkg(T;
+function metadata_pkg(
+    T;
+    # aliases:
+    name::String="unknown",
+    uuid::String="unknown",
+    url::String="unknown",
+    julia::Union{Missing,Bool}=missing,
+    license::String="unknown",
+    is_wrapper::Bool=false,
 
-                      # aliases:
-                      name::String="unknown",
-                      uuid::String="unknown",
-                      url::String="unknown",
-                      julia::Union{Missing,Bool}=missing,
-                      license::String="unknown",
-                      is_wrapper::Bool=false,
-
-                      # preferred names, corresponding to trait names:
-                      package_name=name,
-                      package_uuid=uuid,
-                      package_url=url,
-                      is_pure_julia=julia,
-                      package_license=license,
-
-                      )
+    # preferred names, corresponding to trait names:
+    package_name=name,
+    package_uuid=uuid,
+    package_url=url,
+    is_pure_julia=julia,
+    package_license=license,
+)
     ex = quote
-        MLJModelInterface.package_name(::Type{<:$T})    = $package_name
-        MLJModelInterface.package_uuid(::Type{<:$T})    = $package_uuid
-        MLJModelInterface.package_url(::Type{<:$T})     = $package_url
-        MLJModelInterface.is_pure_julia(::Type{<:$T})   = $is_pure_julia
+        MLJModelInterface.package_name(::Type{<:$T}) = $package_name
+        MLJModelInterface.package_uuid(::Type{<:$T}) = $package_uuid
+        MLJModelInterface.package_url(::Type{<:$T}) = $package_url
+        MLJModelInterface.is_pure_julia(::Type{<:$T}) = $is_pure_julia
         MLJModelInterface.package_license(::Type{<:$T}) = $package_license
-        MLJModelInterface.is_wrapper(::Type{<:$T})      = $is_wrapper
+        MLJModelInterface.is_wrapper(::Type{<:$T}) = $is_wrapper
     end
     parentmodule(T).eval(ex)
 end
@@ -84,12 +83,12 @@ Helper function to write the metadata for a model `T`.
 * `target_scitype=Unknown`: allowed sc. type of the target (supervised)
 * `output_scitype=Unknown`: allowed sc. type of the transformed data (unsupervised)
 * `supports_weights=false` : whether the model supports sample weights
-* `docstring=""`      : short description of the model
-* `load_path=""`       : where the model is (usually `PackageName.ModelName`)
+* `docstring=""` : short description of the model
+* `load_path=""` : where the model is (usually `PackageName.ModelName`)
 
 ## Example
 
-```
+```julia
 metadata_model(KNNRegressor,
     input_scitype=MLJModelInterface.Table(MLJModelInterface.Continuous),
     target_scitype=AbstractVector{MLJModelInterface.Continuous},
@@ -98,39 +97,39 @@ metadata_model(KNNRegressor,
     load_path="NearestNeighbors.KNNRegressor")
 ```
 """
-function metadata_model(T;
+function metadata_model(
+    T;
+    # aliases:
+    input=Unknown,
+    target=Unknown,
+    output=Unknown,
+    weights::Bool=false,
+    descr::String="",
+    path::String="",
 
-                        # aliases:
-                        input=Unknown,
-                        target=Unknown,
-                        output=Unknown,
-                        weights::Bool=false,
-                        descr::String="",
-                        path::String="",
-
-                        # preferred names, corresponding to trait names:
-                        input_scitype=input,
-                        target_scitype=target,
-                        output_scitype=output,
-                        supports_weights=weights,
-                        docstring=descr,
-                        load_path=path,
-
-                        )
+    # preferred names, corresponding to trait names:
+    input_scitype=input,
+    target_scitype=target,
+    output_scitype=output,
+    supports_weights=weights,
+    docstring=descr,
+    load_path=path,
+)
     if isempty(load_path)
         pname = MLJModelInterface.package_name(T)
         mname = MLJModelInterface.name(T)
         load_path = "MLJModels.$(pname)_.$(mname)"
     end
     ex = quote
-        MLJModelInterface.input_scitype(::Type{<:$T})    = $input_scitype
-        MLJModelInterface.output_scitype(::Type{<:$T})   = $output_scitype
-        MLJModelInterface.target_scitype(::Type{<:$T})   = $target_scitype
+        MLJModelInterface.input_scitype(::Type{<:$T}) = $input_scitype
+        MLJModelInterface.output_scitype(::Type{<:$T}) = $output_scitype
+        MLJModelInterface.target_scitype(::Type{<:$T}) = $target_scitype
         MLJModelInterface.supports_weights(::Type{<:$T}) = $supports_weights
-        MLJModelInterface.load_path(::Type{<:$T})        = $load_path
+        MLJModelInterface.load_path(::Type{<:$T}) = $load_path
 
-        MLJModelInterface.docstring(::Type{<:$T}) =
-            MLJModelInterface.docstring_ext($T; descr=$docstring)
+        function MLJModelInterface.docstring(::Type{<:$T})
+            return MLJModelInterface.docstring_ext($T; descr=$docstring)
+        end
     end
     parentmodule(T).eval(ex)
 end

--- a/src/model_api.jl
+++ b/src/model_api.jl
@@ -18,8 +18,8 @@ fit(m::Supervised, verbosity, X, y, w) = fit(m, verbosity, X, y)
 # fallback for unsupervised annotators when labels or weights appear:
 # this is useful for evaluation and mixed composite models that combine
 # both supervised and unsupervised annotators
-fit(m::UnsupervisedAnnotator, verbosity, X, y) =  fit(m, verbosity, X)
-fit(m::UnsupervisedAnnotator, verbosity, X, y, w) =  fit(m, verbosity, X)
+fit(m::UnsupervisedAnnotator, verbosity, X, y) = fit(m, verbosity, X)
+fit(m::UnsupervisedAnnotator, verbosity, X, y, w) = fit(m, verbosity, X)
 
 """
     MLJModelInterface.update(model, verbosity, fitresult, cache, data...)
@@ -28,8 +28,9 @@ Models may optionally implement an `update` method. The fallback calls
 `fit`.
 
 """
-update(m::Model, verbosity, fitresult, cache, data...) =
-    fit(m, verbosity, data...)
+function update(m::Model, verbosity, fitresult, cache, data...)
+    return fit(m, verbosity, data...)
+end
 
 """
     MLJModelInterface.training_losses(model::M, report)
@@ -118,6 +119,7 @@ overload `predict_mean`.
 
 """
 function predict_mean end
+
 """
 
 Models types `M` for which `prediction_type(M) == :probablisitic` may

--- a/src/model_traits.jl
+++ b/src/model_traits.jl
@@ -1,34 +1,41 @@
 ## OVERLOADING TRAIT DEFAULTS RELEVANT TO MODELS
 
 # unexported aliases:
-const Detector = Union{SupervisedDetector,UnsupervisedDetector}
-const ProbabilisticDetector = Union{ProbabilisticSupervisedDetector,
-                                    ProbabilisticUnsupervisedDetector}
-const DeterministicDetector = Union{DeterministicSupervisedDetector,
-                                    DeterministicUnsupervisedDetector}
+const Detector = Union{SupervisedDetector, UnsupervisedDetector}
+const ProbabilisticDetector = Union{
+    ProbabilisticSupervisedDetector,
+    ProbabilisticUnsupervisedDetector
+}
+const DeterministicDetector = Union{
+    DeterministicSupervisedDetector,
+    DeterministicUnsupervisedDetector
+}
 
 const StatTraits = StatisticalTraits
 
 StatTraits.docstring(M::Type{<:MLJType}) = name(M)
-StatTraits.docstring(M::Type{<:Model}) =
-    "$(name(M)) from $(package_name(M)).jl.\n" *
-    "[Documentation]($(package_url(M)))."
 
-StatTraits.is_supervised(::Type{<:Supervised})          = true
+function StatTraits.docstring(M::Type{<:Model})
+    return "$(name(M)) from $(package_name(M)).jl.\n" *
+        "[Documentation]($(package_url(M)))."
+end
+
+StatTraits.is_supervised(::Type{<:Supervised}) = true
 StatTraits.is_supervised(::Type{<:SupervisedAnnotator}) = true
 
 StatTraits.prediction_type(::Type{<:Deterministic}) = :deterministic
 StatTraits.prediction_type(::Type{<:Probabilistic}) = :probabilistic
-StatTraits.prediction_type(::Type{<:Interval})      = :interval
-StatTraits.prediction_type(::Type{<:ProbabilisticDetector}) =
-    :probabilistic
-StatTraits.prediction_type(::Type{<:DeterministicDetector}) =
-    :deterministic
+StatTraits.prediction_type(::Type{<:Interval}) = :interval
+StatTraits.prediction_type(::Type{<:ProbabilisticDetector}) = :probabilistic
+StatTraits.prediction_type(::Type{<:DeterministicDetector}) = :deterministic
 
-StatTraits.target_scitype(::Type{<:ProbabilisticDetector}) =
-    AbstractVector{<:Union{Missing,OrderedFactor{2}}}
-StatTraits.target_scitype(::Type{<:DeterministicDetector}) =
-    AbstractVector{<:Union{Missing,OrderedFactor{2}}}
+function StatTraits.target_scitype(::Type{<:ProbabilisticDetector})
+    return AbstractVector{<:Union{Missing,OrderedFactor{2}}}
+end
+
+function StatTraits.target_scitype(::Type{<:DeterministicDetector})
+    return AbstractVector{<:Union{Missing, OrderedFactor{2}}}
+end
 
 # implementation is deferred as it requires methodswith which depends upon
 # InteractiveUtils which we don't want to bring here as a dependency
@@ -45,40 +52,41 @@ end
 function supervised_fit_data_scitype(M)
     I = input_scitype(M)
     T = target_scitype(M)
-    ret = Tuple{I,T}
+    ret = Tuple{I, T}
     if supports_weights(M)
-        W = AbstractVector{Union{Continuous,Count}} # weight scitype
-        return Union{ret,Tuple{I,T,W}}
+        W = AbstractVector{Union{Continuous, Count}} # weight scitype
+        return Union{ret, Tuple{I, T, W}}
     elseif supports_class_weights(M)
-        W = AbstractDict{Finite,Union{Continuous,Count}}
-        return Union{ret,Tuple{I,T,W}}
+        W = AbstractDict{Finite, Union{Continuous, Count}}
+        return Union{ret, Tuple{I, T, W}}
     end
     return ret
 end
 
-StatTraits.fit_data_scitype(M::Type{<:Unsupervised}) =
-    Tuple{input_scitype(M)}
+StatTraits.fit_data_scitype(M::Type{<:Unsupervised}) = Tuple{input_scitype(M)}
 StatTraits.fit_data_scitype(::Type{<:Static}) = Tuple{}
-StatTraits.fit_data_scitype(M::Type{<:Supervised}) =
-    supervised_fit_data_scitype(M)
+StatTraits.fit_data_scitype(M::Type{<:Supervised}) = supervised_fit_data_scitype(M)
 
 # In special case of `UnsupervisedAnnotator`, we allow the target 
 # as an optional argument to `fit` (that is ignored) so that the
 # `machine` constructor will accept it as a valid argument, which
 # then enables *evaluation* of the detector with labeled data:
-StatTraits.fit_data_scitype(M::Type{<:UnsupervisedAnnotator}) =
-    Union{Tuple{input_scitype(M)}, supervised_fit_data_scitype(M)}
-StatTraits.fit_data_scitype(M::Type{<:SupervisedAnnotator}) =
-    supervised_fit_data_scitype(M)
+function StatTraits.fit_data_scitype(M::Type{<:UnsupervisedAnnotator})
+    return Union{Tuple{input_scitype(M)}, supervised_fit_data_scitype(M)}
+end
 
-StatTraits.transform_scitype(M::Type{<:Unsupervised}) =
-    output_scitype(M)
+function StatTraits.fit_data_scitype(M::Type{<:SupervisedAnnotator})
+    return supervised_fit_data_scitype(M)
+end
 
-StatTraits.inverse_transform_scitype(M::Type{<:Unsupervised}) =
-    input_scitype(M)
+StatTraits.transform_scitype(M::Type{<:Unsupervised}) = output_scitype(M)
+StatTraits.inverse_transform_scitype(M::Type{<:Unsupervised}) = input_scitype(M)
 
-StatTraits.predict_scitype(M::Type{<:Union{
-    Deterministic,DeterministicDetector}}) = target_scitype(M)
+function StatTraits.predict_scitype(
+    M::Type{<:Union{Deterministic, DeterministicDetector}}
+)
+    return target_scitype(M)
+end
 
 ## FALLBACKS FOR `predict_scitype` FOR `Probabilistic` and
 ## `ProbabilisticDetector` MODELS
@@ -87,39 +95,50 @@ StatTraits.predict_scitype(M::Type{<:Union{
 # in `prediction_type` for models which, historically, have not
 # implemented the trait.
 
-StatTraits.predict_scitype(
-    M::Type{<:Union{Probabilistic,ProbabilisticDetector}}
-) = _density(target_scitype(M))
-
-_density(::Any) = Unknown
-for T in [:Continuous, :Count, :Textual]
-    eval(quote
-         _density(::Type{AbstractArray{$T,D}}) where D =
-         AbstractArray{Density{$T},D}
-         end)
+function StatTraits.predict_scitype(
+    M::Type{<:Union{Probabilistic, ProbabilisticDetector}}
+)
+    return _density(target_scitype(M))
 end
 
-for T in [:Finite,
-          :Multiclass,
-          :OrderedFactor,
-          :Infinite,
-          :Continuous,
-          :Count,
-          :Textual]
-    eval(quote
-         _density(::Type{AbstractArray{<:$T,D}}) where D =
-         AbstractArray{Density{<:$T},D}
-         _density(::Type{Table($T)}) = Table(Density{$T})
-         end)
+_density(::Any) = Unknown
+
+for T in [:Continuous, :Count, :Textual]
+    eval(
+        quote
+            function _density(::Type{AbstractArray{$T, D}}) where D
+                return AbstractArray{Density{$T}, D}
+            end
+        end
+    )
+end
+
+for T in [:Finite, :Multiclass, :OrderedFactor, :Infinite, :Continuous, :Count, :Textual]
+    eval(
+        quote
+            function _density(::Type{AbstractArray{<:$T, D}}) where D
+                return AbstractArray{Density{<:$T}, D}
+            end
+
+            _density(::Type{Table($T)}) = Table(Density{$T})
+        end
+    )
 end
 
 
 for T in [:Finite, :Multiclass, :OrderedFactor]
-    eval(quote
-         _density(::Type{AbstractArray{<:$T{N},D}}) where {N,D} =
-         AbstractArray{Density{<:$T{N}},D}
-         _density(::Type{AbstractArray{$T{N},D}}) where {N,D} =
-         AbstractArray{Density{$T{N}},D}
-         _density(::Type{Table($T{N})}) where N = Table(Density{$T{N}})
-         end)
+    eval(
+        quote
+            function _density(::Type{AbstractArray{<:$T{N}, D}}) where {N, D}
+                return AbstractArray{Density{<:$T{N}}, D}
+            end
+
+            function _density(::Type{AbstractArray{$T{N}, D}}) where {N, D}
+                return AbstractArray{Density{$T{N}}, D}
+            end
+
+            _density(::Type{Table($T{N})}) where N = Table(Density{$T{N}})
+        end
+    )
 end
+

--- a/src/parameter_inspection.jl
+++ b/src/parameter_inspection.jl
@@ -12,20 +12,22 @@ values, which themselves might be transparent.
 
 Most objects of type `MLJType` are transparent.
 
-    julia> params(EnsembleModel(atom=ConstantClassifier()))
-    (atom = (target_type = Bool,),
-     weights = Float64[],
-     bagging_fraction = 0.8,
-     rng_seed = 0,
-     n = 100,
-     parallel = true,)
-
+```julia
+julia> params(EnsembleModel(atom=ConstantClassifier()))
+(atom = (target_type = Bool,),
+weights = Float64[],
+bagging_fraction = 0.8,
+rng_seed = 0,
+n = 100,
+parallel = true,)
+```
 """
 params(m) = params(m, Val(istransparent(m)))
 params(m, ::Val{false}) = m
+
 function params(m, ::Val{true})
     fields = fieldnames(typeof(m))
-    NamedTuple{fields}(Tuple([params(getfield(m, field)) for field in fields]))
+    return NamedTuple{fields}(Tuple([params(getfield(m, field)) for field in fields]))
 end
 
 

--- a/test/data_utils.jl
+++ b/test/data_utils.jl
@@ -12,24 +12,29 @@ end
 # ------------------------------------------------------------------------
 @testset "matrix-light" begin
     setlight()
-    X = ones(2,3)
+    X = ones(2, 3)
     @test matrix(X) === X
-    @test matrix(X, transpose=true) == ones(3,2)
-    X = (1,2,3)
-    @test_throws ArgumentError matrix(X)
-    X = (a=[1,2,3],b=[1,2,3])
+    @test matrix(X, transpose=true) == ones(3, 2)
+
+    # The following tests should throw a M.InterfaceError
+    # as we can't know apriori what the trait of `X` is without
+    # needing the `FullInterface`.
+    X = (1, 2, 3)
+    @test_throws M.InterfaceError matrix(X)
+    
+    X = (a=[1, 2, 3], b=[1, 2, 3])
     @test_throws M.InterfaceError matrix(X)
 end
 @testset "matrix-full" begin
     setfull()
     M.matrix(::FI, ::Val{:table}, X; kw...) = Tables.matrix(X; kw...)
-    X = (a=[1,2,3],b=[1,2,3])
-    @test matrix(X) == hcat([1,2,3],[1,2,3])
+    X = (a=[1, 2, 3], b=[1, 2, 3])
+    @test matrix(X) == hcat([1, 2, 3], [1, 2, 3])
 end
 # ------------------------------------------------------------------------
 @testset "int-light" begin
     setlight()
-    x = categorical([1,2,3])
+    x = categorical([1, 2, 3])
     @test_throws M.InterfaceError int(x)
 end
 @testset "int-full" begin
@@ -68,9 +73,11 @@ end
 @testset "schema-full" begin
     setfull()
     ary = rand(10, 3)
-    @test M.schema(ary) === nothing
     M.schema(::FI, ::Val{:table}, X; kw...) =
-        ScientificTypes.schema(X; kw...) 
+        ScientificTypes.schema(X; kw...)
+    M.schema(::FI, ::Val{:other}, X; kw...) = nothing
+
+    @test M.schema(ary) === nothing 
     df = DataFrame(A = rand(10), B = categorical(rand('a':'c', 10)))
     sch = M.schema(df)
     @test sch.names == (:A, :B)
@@ -81,10 +88,20 @@ end
 end
 # ------------------------------------------------------------------------
 @testset "istable" begin
+    # Nothing stops someone from implementing a Tables.jl
+    # interface that subtypes `AbstractArray`, so therefore 
+    # `istable` should throw an error for `LightInterface`
     setlight()
     X = rand(5)
+    @test_throws M.InterfaceError M.istable(X)
+    X = randn(5, 5)
+    @test_throws M.InterfaceError M.istable(X)
+    
+    # The method runs in `FullInterface`
+    setfull()
+    X = rand(5)
     @test !M.istable(X)
-    X = randn(5,5)
+    X = rand(5, 5)
     @test !M.istable(X)
     X = DataFrame(A=rand(10))
     @test M.istable(X)
@@ -104,7 +121,7 @@ end
 # ------------------------------------------------------------------------
 @testset "table-light" begin
     setlight()
-    X = ones(3,2)
+    X = ones(3, 2)
     @test_throws M.InterfaceError table(X)
 end
 @testset "table-full" begin
@@ -113,7 +130,7 @@ end
         _names = [Symbol(:x, j) for j in 1:size(A, 2)]
         return Tables.table(A, header=_names)
     end
-    X = ones(3,2)
+    X = ones(3, 2)
     T = table(X)
     @test Tables.istable(T)
     @test Tables.matrix(T) == X
@@ -121,20 +138,23 @@ end
 # ------------------------------------------------------------------------
 @testset "nrows-light" begin
     setlight()
-    X = ones(5)
-    @test nrows(X) == 5
-    X = ones(5,3)
-    @test nrows(X) == 5
-    X = ones(5,3,2)
-    @test_throws ArgumentError nrows(X)
-    X = (a=[4,2,1],b=[3,2,1])
+    X = (a=[4, 2, 1], b=[3, 2, 1])
     @test_throws M.InterfaceError nrows(X)
     @test nrows(nothing) == 0
 end
 @testset "nrows-full" begin
     setfull()
+    X = ones(5)
+    @test nrows(X) == 5
+    X = ones(5, 3)
+    @test nrows(X) == 5 
+    # It doesn't make sense to get the numbers of rows for 
+    # `AbstractArray`'s of dimension 3 or more. Except if these are 
+    # defined as Tables. Hence `FullInterface` would be required to check this 
+    X = ones(5, 3, 2)
+    @test_throws ArgumentError nrows(X)
     M.nrows(::FI, ::Val{:table}, X) = Tables.rowcount(X)
-    X = (a=[4,2,1],b=[3,2,1])
+    X = (a=[4, 2, 1], b=[3, 2, 1])
     @test nrows(X) == 3
 end
 # ------------------------------------------------------------------------
@@ -145,51 +165,53 @@ end
     X = nothing
     @test selectrows(X, 1) === nothing
     @test selectcols(X, 1) === nothing
-    @test select(X, 1, 2)  === nothing
+    @test select(X, 1, 2) === nothing
 
+    # table
+    X = (x=[1, 1, 1], y=[2, 2, 2])
+    @test_throws M.InterfaceError selectrows(X, 1)
+    @test_throws M.InterfaceError selectcols(X, 1)
+
+    # something else
+    # For this case we would need `FullInterface`.
+    X = (1, 2, 3)
+    @test_throws M.InterfaceError selectrows(X, 1)
+    @test_throws M.InterfaceError selectcols(X, 1)
+    @test_throws M.InterfaceError select(X, 1, 1)
+end
+@testset "select-full" begin
+    setfull()
+   
+    # test fallback
+    X = nothing
+    @test selectrows(X, 1) === nothing
+    @test selectcols(X, 1) === nothing
+    @test select(X, 1, 2) === nothing
+    
     # vector
     X = ones(5)
-    @test selectrows(X, 1)   == [1.0]
+    @test selectrows(X, 1) == [1.0]
     @test selectrows(X, 1:2) == ones(2,)
-    @test selectrows(X, :)  === X
+    @test selectrows(X, :) === X
     @test_throws ArgumentError selectcols(X, 5)
     @test_throws ArgumentError select(X, 2, 2)
 
     # matrix
     X = ones(5, 3)
-    @test selectrows(X, 1)    == ones(1, 3)
-    @test selectrows(X, 1:2)  == ones(2, 3)
-    @test selectrows(X, :)   === X
-    @test selectcols(X, 1)    == ones(5,)
-    @test selectcols(X, 1:2)  == ones(5, 2)
-    @test selectcols(X, :)   === X
-    @test select(X, 1, 1)     == 1.0
-    @test select(X, 1:2, 1)   == ones(2,)
+    @test selectrows(X, 1) == ones(1, 3)
+    @test selectrows(X, 1:2) == ones(2, 3)
+    @test selectrows(X, :) === X
+    @test selectcols(X, 1) == ones(5,)
+    @test selectcols(X, 1:2) == ones(5, 2)
+    @test selectcols(X, :) === X
+    @test select(X, 1, 1) == 1.0
+    @test select(X, 1:2, 1) == ones(2,)
     @test select(X, 1:2, 1:2) == ones(2, 2)
-
-    # table
-    X = (x=[1,1,1],y=[2,2,2])
-    @test_throws M.InterfaceError selectrows(X, 1)
-    @test_throws M.InterfaceError selectcols(X, 1)
-
-    # something else
-    X = (1,2,3)
-    selectrows(X, 1) == X
-    @test_throws ArgumentError selectcols(X, 1)
-    @test_throws ArgumentError select(X, 1, 1)
-end
-@testset "select-full" begin
-    setfull()
-
-    # test fallback
-    X = nothing
-    @test selectrows(X, 1) === nothing
-    @test selectcols(X, 1) === nothing
-    @test select(X, 1, 2)  === nothing
 
     # implement some behaviour:
     M.selectrows(::FI, ::Val{:table}, X, ::Colon) = X
     M.selectcols(::FI, ::Val{:table}, X, ::Colon) = X
+
     function M.selectrows(::FI, ::Val{:table}, X, r)
         r = r isa Integer ? (r:r) : r
         cols = Tables.columntable(X)
@@ -206,48 +228,54 @@ end
         return Tables.materializer(X)(newcols)
     end
     # project named tuple onto a tuple with only specified `labels` or indices:
-    project(t::NamedTuple, labels::AbstractArray{Symbol}) =
-        NamedTuple{tuple(labels...)}(t)
+    function project(t::NamedTuple, labels::AbstractArray{Symbol})
+        return NamedTuple{tuple(labels...)}(t)
+    end
+
     project(t::NamedTuple, label::Colon) = t
     project(t::NamedTuple, label::Symbol) = project(t, [label,])
-    project(t::NamedTuple, indices::AbstractArray{<:Integer}) =
-        NamedTuple{tuple(keys(t)[indices]...)}(tuple([t[i] for i in indices]...))
+    
+    function project(t::NamedTuple, indices::AbstractArray{<:Integer})
+        return NamedTuple{tuple(keys(t)[indices]...)}(tuple([t[i] for i in indices]...))
+    end
+    
     project(t::NamedTuple, i::Integer) = project(t, [i,])
 
-    X = (x=[1,2,3],y=[4,5,6], z=[0,0,0])
-    @test selectrows(X, 1)   == (x=[1],y=[4],z=[0])
-    @test selectrows(X, 1:2) == (x=[1,2],y=[4,5],z=[0,0])
-    @test selectrows(X, :)  === X
-    @test selectcols(X, 1)   == [1,2,3]
+    X = (x=[1, 2, 3], y=[4, 5, 6], z=[0, 0, 0])
+    @test selectrows(X, 1) == (x=[1], y=[4], z=[0])
+    @test selectrows(X, 1:2) == (x=[1, 2], y=[4, 5], z=[0, 0])
+    @test selectrows(X, :) === X
+    @test selectcols(X, 1) == [1, 2, 3]
     @test selectcols(X, 1:2) == (x = [1, 2, 3], y = [4, 5, 6])
-    @test selectcols(X, :)  === X
-    @test select(X, 1, 1)    == 1
-    @test select(X, 1:2, 1)  == [1,2]
-    @test select(X, :, 1)    == [1,2,3]
-    @test selectcols(X, :x)  == [1,2,3]
-    @test select(X, 1:2, :z) == [0,0]
-    #
+    @test selectcols(X, :) === X
+    @test select(X, 1, 1) == 1
+    @test select(X, 1:2, 1) == [1, 2]
+    @test select(X, :, 1) == [1, 2, 3]
+    @test selectcols(X, :x) == [1, 2, 3]
+    @test select(X, 1:2, :z) == [0, 0]
+    
     # extra tests by Anthony
-    X = (x=[1,2,3], y=[10, 20, 30], z= [:a, :b, :c])
-    @test select(X, 2, :y)         == 20
-    @test select(X, 2, [:x, :y])   == (x=[2,], y=[20,])
-    @test select(X, 2:3, :x)       == [2, 3]
+    X = (x=[1, 2, 3], y=[10, 20, 30], z= [:a, :b, :c])
+    @test select(X, 2, :y) == 20
+    @test select(X, 2, [:x, :y]) == (x=[2,], y=[20,])
+    @test select(X, 2:3, :x) == [2, 3]
     @test select(X, 2:3, [:x, :y]) == (x=[2, 3], y=[20, 30])
-    @test select(X, :, [:x, :y])   == select(X, 1:3, [:x, :y])
-    @test select(X, 2, :)          == select(X, 2, 1:3)
-    @test select(X, 2:3, :)        == select(X, 2:3, 1:3)
+    @test select(X, :, [:x, :y]) == select(X, 1:3, [:x, :y])
+    @test select(X, 2, :) == select(X, 2, 1:3)
+    @test select(X, 2:3, :) == select(X, 2:3, 1:3)
 
-    @test select(X, 2, 2)        == 20
-    @test select(X, 2, [1, 2])   == (x=[2,], y=[20,])
-    @test select(X, 2:3, 1)      == [2, 3]
+    @test select(X, 2, 2) == 20
+    @test select(X, 2, [1, 2]) == (x=[2,], y=[20,])
+    @test select(X, 2:3, 1) == [2, 3]
     @test select(X, 2:3, [1, 2]) == (x=[2, 3], y=[20, 30])
-    @test select(X, :, [1, 2])   == select(X, 1:3, [1, 2])
-    @test select(X, 2, :)        == select(X, 2, 1:3)
-    @test select(X, 2:3, :)      == select(X, 2:3, 1:3)
+    @test select(X, :, [1, 2]) == select(X, 1:3, [1, 2])
+    @test select(X, 2, :) == select(X, 2, 1:3)
+    @test select(X, 2:3, :) == select(X, 2:3, 1:3)
 end
+
 # ------------------------------------------------------------------------
 @testset "univ-finite" begin
     setlight()
-    @test_throws M.InterfaceError UnivariateFinite(Dict(2=>3,3=>4))
+    @test_throws M.InterfaceError UnivariateFinite(Dict(2=>3, 3=>4))
     @test_throws M.InterfaceError UnivariateFinite(randn(2), randn(2))
 end

--- a/test/equality.jl
+++ b/test/equality.jl
@@ -11,8 +11,7 @@ end
 mutable struct Bar{names} <: MLJType
     rng::AbstractRNG
     v::Tuple{Int,Int}
-    Bar{names}(rng, x, y) where names =
-        new{names}(rng, (x, y))
+    Bar{names}(rng, x, y) where names = new{names}(rng, (x, y))
 end
 
 Bar(rng, x, y) = Bar{(:x, :y)}(rng, x, y)
@@ -21,6 +20,7 @@ Bar(rng, x, y) = Bar{(:x, :y)}(rng, x, y)
 # the names given in `names` (which will be (:x, :y) when using
 # the above constructor):
 Base.propertynames(::Bar{names}) where names = (:rng, names...)
+
 function Base.getproperty(b::Bar{names}, name::Symbol) where names
     name === :rng && return getfield(b, :rng)
     v = getfield(b, :v)
@@ -35,7 +35,7 @@ function Base.setproperty!(b::Bar{names}, name::Symbol, value) where names
         return value
     end
     setfield!(b, :v, (v[1], value))
-    value
+    return value
 end
 
 mutable struct Super <: MLJType
@@ -63,14 +63,12 @@ mutable struct Super2 <: MLJType
     z::Int
 end
 
-
 MLJModelInterface.deep_properties(::Type{<:Super2}) = (:sub,)
 
 @testset "_isdefined" begin
     b = Bar(MersenneTwister(), 2, 3)
     @test MLJModelInterface._isdefined(b, :x)
 end
-
 
 @testset "_equal_to_depth_one" begin
     d1 = Deep(1, 2)
@@ -83,7 +81,6 @@ end
     d2 = Deep(1, Sub(2))
     @test !MLJModelInterface._equal_to_depth_one(d1, d2)
 end
-
 
 @testset "equality for MLJType" begin
     f1 = Foo(MersenneTwister(7), 1, 2)
@@ -111,8 +108,10 @@ end
 
     @test !(f1 == Super(f1, 4))
 
-    @test !(isequal(Foo(MersenneTwister(1), 1, 2),
-                    Foo(MersenneTwister(1), 1, 2)))
+    @test !isequal(
+        Foo(MersenneTwister(1), 1, 2),
+        Foo(MersenneTwister(1), 1, 2)
+    )
 
     p1 = Partial(1)
     p2 = Partial(1)

--- a/test/model_api.jl
+++ b/test/model_api.jl
@@ -43,10 +43,9 @@ struct DummyUnivariateFinite end
 mutable struct UnivariateFiniteFitter <: Probabilistic end
 
 @testset "models fitting a distribution to data" begin
+    MMI = MLJModelInterface
 
-    function MLJModelInterface.fit(model::UnivariateFiniteFitter,
-                                   verbosity::Int, X, y)
-
+    function MMI.fit(model::UnivariateFiniteFitter, verbosity::Int, X, y)
         fitresult = DummyUnivariateFinite()
         report = nothing
         cache = nothing
@@ -56,22 +55,21 @@ mutable struct UnivariateFiniteFitter <: Probabilistic end
         return fitresult, cache, report
     end
 
-    MLJModelInterface.predict(model::UnivariateFiniteFitter,
-                          fitresult,
-                          X) = fill(fitresult, length(X))
+    function MMI.predict(model::UnivariateFiniteFitter, fitresult, X)
+        return fill(fitresult, length(X))
+    end
 
-    MLJModelInterface.input_scitype(::Type{<:UnivariateFiniteFitter}) =
-        Nothing
-    MLJModelInterface.target_scitype(::Type{<:UnivariateFiniteFitter}) =
-        AbstractVector{<:Finite}
+    MMI.input_scitype(::Type{<:UnivariateFiniteFitter}) = Nothing
+    
+    MMI.target_scitype(::Type{<:UnivariateFiniteFitter}) = AbstractVector{<:Finite}
 
-    y =categorical(collect("aabbccaa"))
+    y = categorical(collect("aabbccaa"))
     X = nothing
     model = UnivariateFiniteFitter()
-    fitresult, cache, report = MLJModelInterface.fit(model, 1, X, y)
+    fitresult, cache, report = MMI.fit(model, 1, X, y)
 
-    @test cache == nothing
-    @test report == nothing
+    @test cache === nothing
+    @test report === nothing
 
     ytest = y[1:3]
     yhat = predict(model, fitresult, fill(nothing, 3))

--- a/test/model_def.jl
+++ b/test/model_def.jl
@@ -11,7 +11,7 @@ end
             warn *= "Field a is negative, resetting to 5."
             a.f0 = 5
         end
-    return warn
+        return warn
     end
     a = A0(-2)
     @test clean!(a) == "Field a is negative, resetting to 5."

--- a/test/model_traits.jl
+++ b/test/model_traits.jl
@@ -38,21 +38,21 @@ bar(::P1) = nothing
     @test target_scitype(ms) == Unknown
     @test is_pure_julia(ms)  == false
 
-    @test package_name(ms)    == "unknown"
+    @test package_name(ms) == "unknown"
     @test package_license(ms) == "unknown"
-    @test load_path(ms)       == "unknown"
-    @test package_uuid(ms)    == "unknown"
-    @test package_url(ms)     == "unknown"
+    @test load_path(ms) == "unknown"
+    @test package_uuid(ms) == "unknown"
+    @test package_url(ms) == "unknown"
 
-    @test is_wrapper(ms)       == false
-    @test supports_online(ms)  == false
+    @test is_wrapper(ms) == false
+    @test supports_online(ms) == false
     @test supports_weights(ms) == false
     @test iteration_parameter(ms) === nothing
 
     @test hyperparameter_ranges(md) == (nothing,)
 
     @test docstring(ms) == "S1 from unknown.jl.\n[Documentation](unknown)."
-    @test name(ms)      == "S1"
+    @test name(ms) == "S1"
 
     @test is_supervised(ms)
     @test is_supervised(sa)
@@ -69,9 +69,13 @@ bar(::P1) = nothing
     # implemented methods is deferred
     setlight()
     @test_throws M.InterfaceError implemented_methods(mp)
+    
     setfull()
-    M.implemented_methods(::FI, M::Type{<:MLJType}) =
-        getfield.(methodswith(M), :name)
+    
+    function M.implemented_methods(::FI, M::Type{<:MLJType})
+        return getfield.(methodswith(M), :name)
+    end
+
     @test Set(implemented_methods(mp)) == Set([:clean!,:bar,:foo])
 end
 
@@ -92,8 +96,10 @@ end
 
 @testset "`_density` - helper for predict_scitype fallback" begin
     for T in [Continuous, Count, Textual]
-        @test M._density(AbstractArray{T,3}) ==
+        @test ==(
+            M._density(AbstractArray{T,3}),
             AbstractArray{Density{T},3}
+        )
     end
 
     for T in [Finite,
@@ -103,16 +109,22 @@ end
               Continuous,
               Count,
               Textual]
-        @test M._density(AbstractVector{<:T}) ==
+        @test ==(
+            M._density(AbstractVector{<:T}),
             AbstractVector{Density{<:T}}
+        )
         @test M._density(Table(T)) == Table(Density{T})
     end
 
     for T in [Finite, Multiclass, OrderedFactor]
-        @test M._density(AbstractArray{<:T{2},3}) ==
+        @test ==(
+            M._density(AbstractArray{<:T{2},3}),
             AbstractArray{Density{<:T{2}},3}
-        @test M._density(AbstractArray{T{2},3}) ==
+        )
+        @test ==(
+            M._density(AbstractArray{T{2},3}),
             AbstractArray{Density{T{2}},3}
+        )
         @test M._density(Table(T{2})) == Table(Density{T{2}})
     end
 end
@@ -146,8 +158,10 @@ end
     @test abstract_type(D1()) == Deterministic
     @test abstract_type(P1()) == Probabilistic
 
-    @test fit_data_scitype(P2()) ==
-        Tuple{Table(Continuous),AbstractVector{<:Multiclass}}
+    @test ==(
+        fit_data_scitype(P2()),
+        Tuple{Table(Continuous), AbstractVector{<:Multiclass}}
+    )
     @test fit_data_scitype(U2()) == Tuple{Table(Continuous)}
     @test fit_data_scitype(S2()) == Tuple{}
 end

--- a/test/parameter_inspection.jl
+++ b/test/parameter_inspection.jl
@@ -23,9 +23,13 @@ end
     t= Transparent(6, Opaque(5))
     m = Dummy(t, Opaque(7), 42)
 
-    @test params(m) == (t = (A = 6,
-                             B = Opaque(5)),
-                        o = Opaque(7),
-                        n = 42)
+    @test params(m) == (
+        t = (
+            A = 6,
+            B = Opaque(5)
+        ),
+        o = Opaque(7),
+        n = 42
+    )
 end
 true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,10 +5,9 @@ import DataFrames: DataFrame
 
 const M  = MLJModelInterface
 const FI = M.FullInterface
-ScientificTypesBase.TRAIT_FUNCTION_GIVEN_NAME[:table] = Tables.istable
 
 setlight() = M.set_interface_mode(M.LightInterface())
-setfull()  = M.set_interface_mode(M.FullInterface())
+setfull() = M.set_interface_mode(M.FullInterface())
 
 include("mode.jl")
 include("parameter_inspection.jl")


### PR DESCRIPTION
With respect to the removal of `TRAIT_FUNCTION_GIVEN_NAME`, `trait` function and `SET_CONVENTION`  in [this ScientificTypesBase.jl PR](https://github.com/JuliaAI/ScientificTypesBase.jl/pull/24) (see also https://github.com/JuliaAI/ScientificTypesBase.jl/issues/25). The following non-breaking changes have been made.
1. The Internal `vtrait` method has been slightly modified and no longer depends on `trait` method from `ScientificTypesBase`. This method now requires the `FullInterface` to run.
2. redefined `MODE` type as a `Union` type rather than an abstract type, to prevent users from extending this method, as that would affect performance ( so we take advantage of `julia`'s union splitting)
2. Code re-formatting (following Invenia [BlueStyle](https://github.com/invenia/BlueStyle)) and docstrings updates. (Well maybe this wasn't necessary)
3. The following data utils methods now require `FullInterface` mode in order to run otherwise they throw an `InterfaceError`. (This is non-breaking to developers as their code would still compile).
    a. `schema`
    b. `istable`
    c. `nrows`
    d. `selectrows`
    e. `selectcols`
    f. `select`

cc. @ablaom 