### PR TITLE
Fix handling weights in supervised fit data scitype

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModelInterface"
 uuid = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 authors = ["Thibaut Lienart and Anthony Blaom"]
-version = "1.3.5"
+version = "1.3.6"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/model_traits.jl
+++ b/src/model_traits.jl
@@ -54,10 +54,10 @@ function supervised_fit_data_scitype(M)
     T = target_scitype(M)
     ret = Tuple{I, T}
     if supports_weights(M)
-        W = AbstractVector{Union{Continuous, Count}} # weight scitype
+        W = AbstractVector{<:Union{Continuous, Count}} # weight scitype
         return Union{ret, Tuple{I, T, W}}
     elseif supports_class_weights(M)
-        W = AbstractDict{Finite, Union{Continuous, Count}}
+        W = AbstractDict{Finite, <:Union{Continuous, Count}}
         return Union{ret, Tuple{I, T, W}}
     end
     return ret
@@ -67,7 +67,7 @@ StatTraits.fit_data_scitype(M::Type{<:Unsupervised}) = Tuple{input_scitype(M)}
 StatTraits.fit_data_scitype(::Type{<:Static}) = Tuple{}
 StatTraits.fit_data_scitype(M::Type{<:Supervised}) = supervised_fit_data_scitype(M)
 
-# In special case of `UnsupervisedAnnotator`, we allow the target 
+# In special case of `UnsupervisedAnnotator`, we allow the target
 # as an optional argument to `fit` (that is ignored) so that the
 # `machine` constructor will accept it as a valid argument, which
 # then enables *evaluation* of the detector with labeled data:


### PR DESCRIPTION
This PR fixes a flaw in the definition of `supervised_fit_data_scitype` which defines the fallback `fit_data_scitype` for `Supervised` models. The problem concerned the case `supports_weights(model)=true` or `supports_class_weights(model)=true`. 

This PR supports https://github.com/JuliaAI/MLJBase.jl/pull/731

cc @pazzo83