### PR TITLE
Address corner case for `synthesize_docstring(M)`

### DIFF
--- a/src/metadata_utils.jl
+++ b/src/metadata_utils.jl
@@ -253,10 +253,15 @@ function synthesize_docstring(M)
     human_name   = MLJModelInterface.human_name(M)
     hyperparameters = MLJModelInterface.hyperparameters(M)
 
-    # generate text for the section on hyperparameters
     text_for_params = ""
-    if !is_wrapper(M)
-        model = M()
+    model = try
+        M()
+    catch ex
+        return ""
+    end
+
+    # generate text for the section on hyperparameters
+    if !is_wrapper(M) 
         isempty(hyperparameters) || (text_for_params *= "# Hyper-parameters")
         for p in hyperparameters
             value = getproperty(model, p)

--- a/src/metadata_utils.jl
+++ b/src/metadata_utils.jl
@@ -181,10 +181,8 @@ metadata_model(FooRegressor,
 Then the docstring is defined post-facto with the following code:
 
 ```
-const HEADER = MLJModelInterface.doc_header(FooRegressor)
-
-@doc \"\"\"
-\$HEADER
+\"\"\"
+\$(MLJModelInterface.doc_header(FooRegressor))
 
 ### Training data
 
@@ -192,7 +190,9 @@ In MLJ or MLJBase, bind an instance `model` ...
 
 <rest of doc string goes here>
 
-\"\"\" FooRegressor
+\"\"\"
+FooRegressor
+
 ```
 
 """
@@ -261,7 +261,7 @@ function synthesize_docstring(M)
     end
 
     # generate text for the section on hyperparameters
-    if !is_wrapper(M) 
+    if !is_wrapper(M)
         isempty(hyperparameters) || (text_for_params *= "# Hyper-parameters")
         for p in hyperparameters
             value = getproperty(model, p)

--- a/test/metadata_utils.jl
+++ b/test/metadata_utils.jl
@@ -1,10 +1,90 @@
+##  SYNTHETIC DOCSTRING
+
+# model type `M` for which `M()` is implemented (typical case):
+
+"""Cool model"""
+@mlj_model mutable struct FooClassifier <: Deterministic
+    a::Int = 0::(_ ≥ 0)
+    b
+end
+
+metadata_pkg(FooClassifier,
+    name="FooClassifierPkg",
+    uuid="10745b16-79ce-11e8-11f9-7d13ad32a3b2",
+    url="http://existentialcomics.com/",
+    julia=true,
+    license="MIT",
+    is_wrapper=false
+    )
+
+metadata_model(FooClassifier,
+               input_scitype=Table(Continuous),
+               target_scitype=AbstractVector{Continuous},
+               supports_class_weights=true,
+               load_path="goo goo")
+
+
+# model type `M` for which `M()` is not implemented:
+
+"""Cool model"""
+mutable struct FooBad <: Deterministic
+    a::Int
+    b
+end
+
+metadata_pkg(FooBad,
+    name="FooBadPkg",
+    uuid="10745b16-79ce-11e8-11f9-7d13ad32a3b2",
+    url="http://existentialcomics.com/",
+    julia=true,
+    license="MIT",
+    is_wrapper=false
+    )
+
+metadata_model(FooBad,
+               input_scitype=Table(Continuous),
+               target_scitype=AbstractVector{Continuous},
+               supports_class_weights=true,
+               load_path="goo goo")
+
+synthetic = M.synthesize_docstring(FooClassifier) |> Markdown.parse
+comparison =
+    """
+        FooClassifier
+
+    Model type for foo classifier, based on
+    [FooClassifierPkg.jl](http://existentialcomics.com/),
+    and implementing the MLJ model interface.
+
+    From MLJ, the type can be imported using
+
+        FooClassifier = @load FooClassifier pkg=FooClassifierPkg
+
+    Do `model = FooClassifier()` to construct an instance with default hyper-parameters.
+    Provide keyword arguments to override hyper-parameter defaults, as in
+    `FooClassifier(a=...)`.
+
+    # Hyper-parameters
+
+    - `a = 0`
+
+    - `b = missing`
+    """ |> Markdown.parse
+
+@testset "synthisise_docstring" begin
+    @test synthetic == comparison
+    @test isempty(M.synthesize_docstring(FooBad))
+end
+
+
+# METADATA_PKG, METADATA_MODEL, DOCUMENT STRINGS
+
+
 """Cool model"""
 @mlj_model mutable struct FooRegressor <: Deterministic
     a::Int = 0::(_ ≥ 0)
     b
 end
-
-struct BarGoo <: Deterministic end
 
 metadata_pkg(FooRegressor,
     name="FooRegressorPkg",


### PR DESCRIPTION
The method fails if `M()` is not defined. Although the interface explicitly requires `M()` to be defined, it occassionally is not in tests that construct dummy models for pure testing purposes. It seems prudent to just return a simpler string in this case, rather than change those tests. 
