### PR TITLE
Tweak doc header

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModelInterface"
 uuid = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 authors = ["Thibaut Lienart and Anthony Blaom"]
-version = "1.4.1"
+version = "1.4.2"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/metadata_utils.jl
+++ b/src/metadata_utils.jl
@@ -140,7 +140,8 @@ something like this:
 
 >    `FooRegressor`
 >
->Model type for foo regressor, based on [FooRegressorPkg.jl](http://existentialcomics.com/).
+>A model type for constructing a foo regressor,
+>based on [FooRegressorPkg.jl](http://existentialcomics.com/).
 >
 >From MLJ, the type can be imported using
 >
@@ -209,7 +210,7 @@ function doc_header(SomeModelType)
         $name
         ```
 
-        Model type for $human_name, based on
+        A model type for constructing a $human_name, based on
         [$(package_name).jl]($package_url), and implementing the MLJ
         model interface.
 

--- a/test/metadata_utils.jl
+++ b/test/metadata_utils.jl
@@ -52,7 +52,7 @@ comparison =
     """
         FooClassifier
 
-    Model type for foo classifier, based on
+    A model type for constructing a foo classifier, based on
     [FooClassifierPkg.jl](http://existentialcomics.com/),
     and implementing the MLJ model interface.
 
@@ -155,7 +155,8 @@ end
 FooRegressor
 ```
 
-Model type for foo regressor, based on [FooRegressorPkg.jl](http://existentialcomics.com/).
+A model type for constructing a foo regressor, based on
+[FooRegressorPkg.jl](http://existentialcomics.com/).
 
 From MLJ, the type can be imported using
 

--- a/test/model_traits.jl
+++ b/test/model_traits.jl
@@ -32,7 +32,7 @@ M.human_name(::Type{<:S1}) = "silly model"
 
 M.package_name(::Type{<:U1}) = "Bach"
 M.package_url(::Type{<:U1}) = "www.did_he_write_565.com"
-M.human_name(::Type{<:U1}) = "my model"
+M.human_name(::Type{<:U1}) = "funky model"
 
 @testset "traits" begin
     ms = S1()
@@ -69,7 +69,7 @@ M.human_name(::Type{<:U1}) = "my model"
         U1
         ```
 
-        Model type for my model, based on
+        A model type for constructing a funky model, based on
         [Bach.jl](www.did_he_write_565.com), and implementing the MLJ
         model interface.
 


### PR DESCRIPTION
Some grammatical awkwardness persists for some model `human_name`s, which this change attempts to address.