### PR TITLE
add `feature_importances` stub 

### DIFF
--- a/src/MLJModelInterface.jl
+++ b/src/MLJModelInterface.jl
@@ -30,6 +30,7 @@ const MODEL_TRAITS = [
     :hyperparameter_ranges,
     :iteration_parameter,
     :supports_training_losses,
+    :reports_intrinsic_importances,
     :deep_properties
 ]
 

--- a/src/MLJModelInterface.jl
+++ b/src/MLJModelInterface.jl
@@ -30,7 +30,7 @@ const MODEL_TRAITS = [
     :hyperparameter_ranges,
     :iteration_parameter,
     :supports_training_losses,
-    :reports_intrinsic_importances,
+    :reports_feature_importances,
     :deep_properties
 ]
 

--- a/src/model_api.jl
+++ b/src/model_api.jl
@@ -174,7 +174,7 @@ abstract vector of `feature::Symbol => importance::Real` pairs
 (e.g `[:gender =>0.23, :height =>0.7, :weight => 0.1]`).  
 
 The following trait overload is also required:
-`:reports_intrinsic_importances(::Type{<:M}) = true`
+`reports_intrinsic_importances(::Type{<:M}) = true`
 
 """
 intrinsic_importances(model, fitresult, report) = nothing

--- a/src/model_api.jl
+++ b/src/model_api.jl
@@ -166,15 +166,15 @@ some meta-models may choose to implement the `evaluate` operations
 function evaluate end
 
 """
-    intrinsic_importances(model::M, fitresult, report)
+    feature_importances(model::M, fitresult, report)
 
 For a given `model` of model type `M` supporting intrinsic feature importances, calculate 
-the intrinsic feature importances from the model's `fitresult` and `report` as an 
+the feature importances from the model's `fitresult` and `report` as an 
 abstract vector of `feature::Symbol => importance::Real` pairs 
 (e.g `[:gender =>0.23, :height =>0.7, :weight => 0.1]`).  
 
 The following trait overload is also required:
-`reports_intrinsic_importances(::Type{<:M}) = true`
+`reports_feature_importances(::Type{<:M}) = true`
 
 """
-intrinsic_importances(model, fitresult, report) = nothing
+feature_importances(model, fitresult, report) = nothing

--- a/src/model_api.jl
+++ b/src/model_api.jl
@@ -176,5 +176,8 @@ abstract vector of `feature::Symbol => importance::Real` pairs
 The following trait overload is also required:
 `reports_feature_importances(::Type{<:M}) = true`
 
+If for some reason a model is sometimes unable to report feature importances then
+`feature_importances` should return all importances as 0.0, as in 
+`[:gender =>0.0, :height =>0.0, :weight => 0.0]`. 
 """
 function feature_importances end

--- a/src/model_api.jl
+++ b/src/model_api.jl
@@ -177,4 +177,4 @@ The following trait overload is also required:
 `reports_feature_importances(::Type{<:M}) = true`
 
 """
-feature_importances(model, fitresult, report) = nothing
+function feature_importances end

--- a/src/model_api.jl
+++ b/src/model_api.jl
@@ -40,7 +40,7 @@ implement this method to return an `AbstractVector` of the losses
 in historical order. If the model calculates scores instead, then the
 sign of the scores should be reversed.
 
-The following trait overload is alse required:
+The following trait overload is also required:
 `supports_training_losses(::Type{<:M}) = true`
 
 """
@@ -164,3 +164,17 @@ function restore end
 some meta-models may choose to implement the `evaluate` operations
 """
 function evaluate end
+
+"""
+    intrinsic_importances(model::M, fitresult, report)
+
+For a given `model` of model type `M` supporting intrinsic feature importances, calculate 
+the intrinsic feature importances from the model's `fitresult` and `report` as an 
+abstract vector of `feature::Symbol => importance::Real` pairs 
+(e.g `[:gender =>0.23, :height =>0.7, :weight => 0.1]`).  
+
+The following trait overload is also required:
+`:reports_intrinsic_importances(::Type{<:M}) = true`
+
+"""
+intrinsic_importances(model, fitresult, report) = nothing

--- a/test/model_api.jl
+++ b/test/model_api.jl
@@ -36,6 +36,10 @@ end
     # training losses:
     f, c, r = MLJModelInterface.fit(m0, 1, rand(2), rand(2))
     @test M.training_losses(m0, r) === nothing
+    
+    # intrinsic_importances
+    f, c, r = MLJModelInterface.fit(m0, 1, rand(2), rand(2))
+    @test M.intrinsic_importances(m0, f, r) === nothing
 end
 
 struct DummyUnivariateFinite end

--- a/test/model_api.jl
+++ b/test/model_api.jl
@@ -39,7 +39,7 @@ end
     
     # intrinsic_importances
     f, c, r = MLJModelInterface.fit(m0, 1, rand(2), rand(2))
-    @test M.intrinsic_importances(m0, f, r) === nothing
+    @test M.feature_importances(m0, f, r) === nothing
 end
 
 struct DummyUnivariateFinite end

--- a/test/model_api.jl
+++ b/test/model_api.jl
@@ -5,6 +5,7 @@ end
     f0::Int
 end
 
+
 mutable struct APIx1 <: Static end
 
 @testset "selectrows(model, data...)" begin
@@ -30,7 +31,7 @@ end
     s1 = APIx1()
     @test fit(s1, 1, 0) == (nothing, nothing, nothing)
 
-    #update fallback = fit
+    # update fallback = fit
     @test update(m0, 1, 5, nothing, randn(2), 5) == (5, nothing, nothing)
 
     # training losses:
@@ -39,7 +40,9 @@ end
     
     # intrinsic_importances
     f, c, r = MLJModelInterface.fit(m0, 1, rand(2), rand(2))
-    @test M.feature_importances(m0, f, r) === nothing
+    MLJModelInterface.reports_feature_importances(::Type{APIx0}) = true
+    MLJModelInterface.feature_importances(::APIx0, fitresult, report) = [:a=>0, :b=>0]
+    @test MLJModelInterface.feature_importances(m0, f, r) == [:a=>0, :b=>0]
 end
 
 struct DummyUnivariateFinite end


### PR DESCRIPTION
This PR adds `feature_importances` stub`. Models which overload this method must also overload the `reports_feature_importances` trait. 

**Requires**:
- [x] https://github.com/JuliaAI/StatisticalTraits.jl/pull/23

**Note**
`feature_importances` stub isn't exported in line with the goals set in this [issue](https://github.com/JuliaAI/MLJModelInterface.jl/issues/132)