### PR TITLE
Escape `MLJModelInterface` in quote

### DIFF
--- a/src/metadata_utils.jl
+++ b/src/metadata_utils.jl
@@ -44,12 +44,12 @@ function metadata_pkg(
     package_license=license,
 )
     ex = quote
-        MLJModelInterface.package_name(::Type{<:$T}) = $package_name
-        MLJModelInterface.package_uuid(::Type{<:$T}) = $package_uuid
-        MLJModelInterface.package_url(::Type{<:$T}) = $package_url
-        MLJModelInterface.is_pure_julia(::Type{<:$T}) = $is_pure_julia
-        MLJModelInterface.package_license(::Type{<:$T}) = $package_license
-        MLJModelInterface.is_wrapper(::Type{<:$T}) = $is_wrapper
+        $MLJModelInterface.package_name(::Type{<:$T}) = $package_name
+        $MLJModelInterface.package_uuid(::Type{<:$T}) = $package_uuid
+        $MLJModelInterface.package_url(::Type{<:$T}) = $package_url
+        $MLJModelInterface.is_pure_julia(::Type{<:$T}) = $is_pure_julia
+        $MLJModelInterface.package_license(::Type{<:$T}) = $package_license
+        $MLJModelInterface.is_wrapper(::Type{<:$T}) = $is_wrapper
     end
     parentmodule(T).eval(ex)
 end
@@ -59,7 +59,7 @@ end
 function _extend!(program::Expr, trait::Symbol, value, T)
     if value !== nothing
         push!(program.args, quote
-              MLJModelInterface.$trait(::Type{<:$T}) = $value
+              $MLJModelInterface.$trait(::Type{<:$T}) = $value
               end)
         return nothing
     end

--- a/test/data_utils.jl
+++ b/test/data_utils.jl
@@ -318,3 +318,14 @@ end
     @test_throws M.InterfaceError UnivariateFinite(Dict(2=>3, 3=>4))
     @test_throws M.InterfaceError UnivariateFinite(randn(2), randn(2))
 end
+
+@testset "don't assume MLJModelInterface at user-side" begin
+    module UserSide
+        import MLJModelInterface: metadata_model, metadata_pkg
+        struct A end
+        descr = "something"
+        # Smoke tests.
+        metadata_model(A; descr=descr)
+        metadata_pkg(A)
+    end
+end

--- a/test/data_utils.jl
+++ b/test/data_utils.jl
@@ -319,13 +319,13 @@ end
     @test_throws M.InterfaceError UnivariateFinite(randn(2), randn(2))
 end
 
-@testset "don't assume MLJModelInterface at user-side" begin
-    module UserSide
-        import MLJModelInterface: metadata_model, metadata_pkg
-        struct A end
-        descr = "something"
-        # Smoke tests.
-        metadata_model(A; descr=descr)
-        metadata_pkg(A)
-    end
+@testset "not assuming MLJModelInterface symbol at user-side" begin
+    eval(:(module UserSide
+            import MLJModelInterface: metadata_model, metadata_pkg
+            struct A end
+            descr = "something"
+            # Smoke tests.
+            metadata_model(A; descr=descr)
+            metadata_pkg(A)
+    end))
 end


### PR DESCRIPTION
Fixes

```julia
julia> import MLJModelInterface: metadata_model

julia> struct A end

julia> metadata_model(A; descr="foo")
ERROR: LoadError: UndefVarError: MLJModelInterface not defined
Stacktrace:
 [1] top-level scope
   @ ~/.julia/packages/MLJModelInterface/Pvz9I/src/metadata_utils.jl:62
 [2] eval
   @ ./boot.jl:368 [inlined]
 [3] eval(x::Expr)
   @ Base.MainInclude ./client.jl:478
 [4] metadata_model(T::Type; input::Nothing, target::Nothing, output::Nothing, weights::Nothing, class_weights::Nothing, descr::String, path::Nothing, input_scitype::Nothing, target_scitype::Nothing, output_scitype::Nothing, supports_weights::Nothing, supports_class_weights::Nothing, docstring::String, load_path::Nothing, human_name::Nothing)
   @ MLJModelInterface ~/.julia/packages/MLJModelInterface/Pvz9I/src/metadata_utils.jl:128
 [5] top-level scope
   @ REPL[26]:1
```
