### PR TITLE
Add `reporting_operations` to list of model traits

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ StatisticalTraits = "64bff920-2084-43da-a3e6-9bb72801c0c9"
 
 [compat]
 ScientificTypesBase = "3.0"
-StatisticalTraits = "3.1"
+StatisticalTraits = "3.2"
 julia = "1"
 
 [extras]

--- a/src/MLJModelInterface.jl
+++ b/src/MLJModelInterface.jl
@@ -31,7 +31,8 @@ const MODEL_TRAITS = [
     :iteration_parameter,
     :supports_training_losses,
     :reports_feature_importances,
-    :deep_properties
+    :deep_properties,
+    :reporting_operations,
 ]
 
 const ABSTRACT_MODEL_SUBTYPES = [


### PR DESCRIPTION
Requires: 

- [x] https://github.com/JuliaAI/StatisticalTraits.jl/pull/25

In support of proposal at MLJBase cross-referenced below.

To do:

- [x] Bump compat for StatisticalTraits