### PR TITLE
Remove Integer type annotation in `fit(::Static, verbosity::Integer, ...)`

### DIFF
--- a/src/model_api.jl
+++ b/src/model_api.jl
@@ -10,7 +10,7 @@ thereof. The fallback of `reformat` returns the user-provided data
 function fit end
 
 # fallback for static transformations
-fit(::Static, ::Integer, data...) = (nothing, nothing, nothing)
+fit(::Static, verbosity, data...) = (nothing, nothing, nothing)
 
 # fallbacks for supervised models that don't support sample weights:
 fit(m::Supervised, verbosity, X, y, w) = fit(m, verbosity, X, y)


### PR DESCRIPTION
This typing is never used for dispatch but is causing some downstream type ambiguities in some MLJBase refactoring I am working on. 

To make sure, let's require:

- [x] MLJTestIngration tests run without surprises