### PR TITLE
Probabilisitic set

### DIFF
--- a/src/MLJModelInterface.jl
+++ b/src/MLJModelInterface.jl
@@ -41,6 +41,7 @@ const ABSTRACT_MODEL_SUBTYPES = [
     :Probabilistic,
     :Deterministic,
     :Interval,
+    :ProbabilisticSet,
     :JointProbabilistic,
     :Static,
     :Annotator,
@@ -143,6 +144,7 @@ abstract type Annotator <: Model end
 abstract type Probabilistic <: Supervised end
 abstract type Deterministic <: Supervised end
 abstract type Interval <: Supervised end
+abstract type ProbabilisticSet <: Supervised end
 
 abstract type JointProbabilistic <: Probabilistic end
 

--- a/src/model_traits.jl
+++ b/src/model_traits.jl
@@ -27,6 +27,7 @@ StatTraits.is_supervised(::Type{<:SupervisedAnnotator}) = true
 StatTraits.prediction_type(::Type{<:Deterministic}) = :deterministic
 StatTraits.prediction_type(::Type{<:Probabilistic}) = :probabilistic
 StatTraits.prediction_type(::Type{<:Interval}) = :interval
+StatTraits.prediction_type(::Type{<:ProbabilisticSet}) = :probabistic_set
 StatTraits.prediction_type(::Type{<:ProbabilisticDetector}) = :probabilistic
 StatTraits.prediction_type(::Type{<:DeterministicDetector}) = :deterministic
 

--- a/src/model_traits.jl
+++ b/src/model_traits.jl
@@ -27,7 +27,7 @@ StatTraits.is_supervised(::Type{<:SupervisedAnnotator}) = true
 StatTraits.prediction_type(::Type{<:Deterministic}) = :deterministic
 StatTraits.prediction_type(::Type{<:Probabilistic}) = :probabilistic
 StatTraits.prediction_type(::Type{<:Interval}) = :interval
-StatTraits.prediction_type(::Type{<:ProbabilisticSet}) = :probabistic_set
+StatTraits.prediction_type(::Type{<:ProbabilisticSet}) = :probabilistic_set
 StatTraits.prediction_type(::Type{<:ProbabilisticDetector}) = :probabilistic
 StatTraits.prediction_type(::Type{<:DeterministicDetector}) = :deterministic
 


### PR DESCRIPTION
Added the abstract type necessary to add conformal classifiers for general use (see [related issue](https://github.com/alan-turing-institute/MLJ.jl/issues/978)). Nothing done yet with respect to downstream tasks. Decided to use only `ProbabilisticSet` for now, as I'm not sure the other case is necessary. Also added the trait definition.