### PR TITLE
Add `augment` option to `doc_header`

### DIFF
--- a/src/metadata_utils.jl
+++ b/src/metadata_utils.jl
@@ -152,7 +152,7 @@ end
 # example given in the docstring for `doc_header`.
 
 """
-    MLJModelInterface.doc_header(SomeModelType)
+    MLJModelInterface.doc_header(SomeModelType; augment=false)
 
 Return a string suitable for interpolation in the document string of
 an MLJ model type. In the example given below, the header expands to
@@ -199,7 +199,7 @@ metadata_model(FooRegressor,
     descr="La di da")
 ```
 
-Then the docstring is defined post-facto with the following code:
+Then the docstring is defined after these declarations with the following code:
 
 ```
 \"\"\"
@@ -216,15 +216,37 @@ FooRegressor
 
 ```
 
+# Variation to augment existing document string
+
+For models that have a native API with separate documentation, one may want to call
+`doc_header(FooRegressor, augment=true)` instead. In that case, the output will look like
+this:
+
+>From MLJ, the `FooRegressor` type can be imported using
+>
+>
+>    `FooRegressor = @load FooRegressor pkg=FooRegressorPkg`
+>
+>Construct an instance with default hyper-parameters using the syntax
+>`model = FooRegressor()`. Provide keyword arguments to override
+>hyper-parameter defaults, as in `FooRegressor(a=...)`.
+
+To prevent an existing document string being *replaced* instead of augmented, the
+`doc_header` declaration must appear in a different module from the original.
+
 """
-function doc_header(SomeModelType)
+function doc_header(SomeModelType; augment=false)
     name = MLJModelInterface.name(SomeModelType)
     human_name = MLJModelInterface.human_name(SomeModelType)
     package_name = MLJModelInterface.package_name(SomeModelType)
     package_url = MLJModelInterface.package_url(SomeModelType)
     params = MLJModelInterface.hyperparameters(SomeModelType)
 
-    ret =
+    top = augment ?
+        """
+        From MLJ, the `$name` type can be imported using
+
+        """ :
         """
         ```
         $name
@@ -235,7 +257,9 @@ function doc_header(SomeModelType)
         model interface.
 
         From MLJ, the type can be imported using
-
+        """
+    ret = top*
+        """
         ```
         $name = @load $name pkg=$package_name
         ```

--- a/test/metadata_utils.jl
+++ b/test/metadata_utils.jl
@@ -158,7 +158,8 @@ FooRegressor
 ```
 
 A model type for constructing a foo regressor, based on
-[FooRegressorPkg.jl](http://existentialcomics.com/).
+[FooRegressorPkg.jl](http://existentialcomics.com/), and implementing the MLJ model
+interface.
 
 From MLJ, the type can be imported using
 
@@ -171,9 +172,73 @@ Provide keyword arguments to override hyper-parameter
 defaults, as in `FooRegressor(a=...)`.
 """ |> chomp |> Markdown.parse
 
+    @test string(header) == string(comparison)
 end
 
 @testset "document string" begin
     doc = (@doc FooRegressor) |> string |> chomp
+    @test endswith(doc, "We have no bananas today!")
+end
+
+
+# # DOC STRING - AUGMENTED CASE
+
+"""Cool model"""
+@mlj_model mutable struct FooRegressor2 <: Deterministic
+    a::Int = 0::(_ ≥ 0)
+    b
+end
+
+metadata_pkg(FooRegressor2,
+    name="FooRegressor2Pkg",
+    uuid="10745b16-79ce-11e8-11f9-7d13ad32a3b2",
+    url="http://existentialcomics.com/",
+    julia=true,
+    license="MIT",
+    is_wrapper=false
+    )
+
+# this is added in MLJBase but not in MLJModelInterface, to avoid
+# InteractiveUtils as dependency:
+setfull()
+M.implemented_methods(::FI, M::Type{<:MLJType}) =
+    getfield.(methodswith(M), :name)
+
+const HEADER2 = MLJModelInterface.doc_header(FooRegressor2, augment=true)
+
+@doc """
+$HEADER2
+
+Yes, we have no bananas. We have no bananas today!
+""" FooRegressor2
+
+@testset "doc_header(ModelType, augment=true)" begin
+
+    # we test markdown parsed strings for less fussy comparison
+
+    header  = Markdown.parse(HEADER2)
+    comparison =
+"""
+```
+FooRegressor2
+```
+
+From MLJ, the `FooRegressor2` type can be imported using
+
+```
+FooRegressor2 = @load FooRegressor2 pkg=FooRegressor2Pkg
+```
+
+Do `model = FooRegressor2()` to construct an instance with default hyper-parameters.
+Provide keyword arguments to override hyper-parameter
+defaults, as in `FooRegressor2(a=...)`.
+""" |> chomp |> Markdown.parse
+
+    @test string(header) == string(comparison)
+
+end
+
+@testset "document string" begin
+    doc = (@doc FooRegressor2) |> string |> chomp
     @test endswith(doc, "We have no bananas today!")
 end

--- a/test/metadata_utils.jl
+++ b/test/metadata_utils.jl
@@ -219,10 +219,6 @@ Yes, we have no bananas. We have no bananas today!
     header  = Markdown.parse(HEADER2)
     comparison =
 """
-```
-FooRegressor2
-```
-
 From MLJ, the `FooRegressor2` type can be imported using
 
 ```


### PR DESCRIPTION
From the new doc string for `doc_header`:

---
# Variation to augment existing document string

For models that have a native API with separate documentation, one may want to call
`doc_header(FooRegressor, augment=true)` instead. In that case, the output will look like
this:

>From MLJ, the `FooRegressor` type can be imported using
>
>
>    `FooRegressor = @load FooRegressor pkg=FooRegressorPkg`
>
>Construct an instance with default hyper-parameters using the syntax
>`model = FooRegressor()`. Provide keyword arguments to override
>hyper-parameter defaults, as in `FooRegressor(a=...)`.

To prevent an existing document string being *replaced* instead of augmented, the
`doc_header` declaration must appear in a different module from the original.
