### PR TITLE
remove misleading descr used in  `doc_header` docstring

### DIFF
--- a/src/metadata_utils.jl
+++ b/src/metadata_utils.jl
@@ -195,8 +195,7 @@ metadata_pkg(FooRegressor,
     )
 metadata_model(FooRegressor,
     input=Table(Continuous),
-    target=AbstractVector{Continuous},
-    descr="La di da")
+    target=AbstractVector{Continuous})
 ```
 
 Then the docstring is defined after these declarations with the following code:


### PR DESCRIPTION
This shows up in the MLJ documentation and can mislead people into thinking that its okay to add `descr` argument when calling the `metadata_model` helper. So I think it's best to remove it from the example. 
@ablaom any thoughts?