### PR TITLE
Fix `@mlj_model` parsing bug

### DIFF
--- a/src/model_def.jl
+++ b/src/model_def.jl
@@ -62,12 +62,12 @@ function _process_model_def(modl, ex)
             if line.head == :(=) # assignment for default
                 default = line.args[2]
                 # if a constraint is given (value::constraint)
-                if default isa Expr && length(default.args) > 1
+                if default isa Expr && default.head == :(::)
                     constraints[param] = default.args[2]
                     # now discard the constraint to keep only the value
                     default = default.args[1]
                 end
-                defaults[param] = default # this will be a value not an expr
+                defaults[param] = default
 
                 # name or name::Type (for the constructor)
                 ex.args[3].args[i] = line.args[1] 

--- a/test/model_def.jl
+++ b/test/model_def.jl
@@ -151,3 +151,26 @@ end
     @test Cc().a === nothing
     @test Cd().a === missing
 end
+
+@testset "Expression defaults" begin
+    # Should work with and without constraint:
+    @mlj_model mutable struct Foo1
+        a::Vector{Int} = [1, 2, 3]
+    end
+    Foo1().a == [1, 2, 3]
+    @mlj_model mutable struct Foo2
+        a::Vector{Int} = [1, 2, 3]::(true)
+    end
+    Foo2().a == [1, 2, 3]
+
+    # Negative number:
+    @mlj_model mutable struct Foo3
+        a::Float64 = -1.0
+    end
+    Foo3().a === -1.0
+    @mlj_model mutable struct Foo4
+        a::Float64 = (-1.0)::(true)
+    end
+    Foo4().a == -1.0
+
+end

--- a/test/model_def.jl
+++ b/test/model_def.jl
@@ -157,20 +157,28 @@ end
     @mlj_model mutable struct Foo1
         a::Vector{Int} = [1, 2, 3]
     end
-    Foo1().a == [1, 2, 3]
+    @test Foo1().a == [1, 2, 3]
     @mlj_model mutable struct Foo2
         a::Vector{Int} = [1, 2, 3]::(true)
     end
-    Foo2().a == [1, 2, 3]
+    @test Foo2().a == [1, 2, 3]
+
+    # Constraints applied
+    @mlj_model mutable struct Foo3
+        a::Vector{Int} = [1, 2, 3]::(all(>(0), _))
+    end
+    @test redirect_stderr(devnull) do
+        Foo3(; a = [-1]).a == [1, 2, 3]
+    end
 
     # Negative number:
-    @mlj_model mutable struct Foo3
+    @mlj_model mutable struct Foo4
         a::Float64 = -1.0
     end
-    Foo3().a === -1.0
-    @mlj_model mutable struct Foo4
+    @test Foo4().a === -1.0
+    @mlj_model mutable struct Foo5
         a::Float64 = (-1.0)::(true)
     end
-    Foo4().a == -1.0
+    @test Foo5().a == -1.0
 
 end


### PR DESCRIPTION
Fixes #174.

The bug was due to `length(default.args) > 1` being used to check whether a constraint was present in the default expression. What should actually be done is `default.head == :(::)`. 

Using `length(default.args)` is incorrect because some defaults can have multiple args, such as

```julia
julia> :([0, 1, 2]).args
3-element Vector{Any}:
 0
 1
 2
```

Likewise, the user might not have used `::` at all to define the constraint.

This PR checks for the `::` operator to identify a constraint which fixes this issue.

Note that this fix is backwards compatible, *so long as people have not been exploiting the bug*. See my note at the end of this post for more details.

With this change, we can now do:

```julia
julia> using MLJModelInterface

julia> @mlj_model mutable struct Foo
           x::Vector{Int} = [0, 1, 2]
           y::Int = -1
       end

julia> Foo()
Foo([0, 1, 2], -1)
```

whereas before you would get an error due to the incorrectly parsed default, which would parse `0` as the default and `1` as the constraint:
```julia
julia> Foo()
ERROR: MethodError: Cannot `convert` an object of type Int64 to an object of type Vector{Int64}

Closest candidates are:
  convert(::Type{T}, ::LinearAlgebra.Factorization) where T<:AbstractArray
   @ LinearAlgebra ~/.julia/juliaup/julia-1.9.1+0.aarch64.apple.darwin14/share/julia/stdlib/v1.9/LinearAlgebra/src/factorization.jl:59
  convert(::Type{T}, ::AbstractArray) where T<:Array
   @ Base array.jl:613
  convert(::Type{T}, ::T) where T<:AbstractArray
   @ Base abstractarray.jl:16
  ...

Stacktrace:
 [1] Foo(; x::Int64, y::Int64)
   @ Main ./none:0
 [2] Foo()
   @ Main ./none:0
 [3] top-level scope
   @ REPL[5]:1
```

cc @ablaom 

---

What changes is that a user can no longer exploit the bug. For example, before you actually do:

```julia
julia> @mlj_model mutable struct Foo
           x::Int = [1, (_ >= 0)]
       end

julia> Foo()
Foo(1)
```

to give a constraint. *Any* expression which has the constraint in the second argument would be a valid way of defining this model. Unless you are aware of anybody doing this, I wouldn't worry about it though.

Now if you try to use that syntax, you would get:

```julia
julia> @mlj_model mutable struct Foo
           x::Int = [1, (_ >= 0)]
       end
ERROR: syntax: all-underscore identifier used as rvalue
Stacktrace:
 [1] top-level scope
   @ REPL[3]:1
```

which is what we want.