### PR TITLE
flat_params hotfix respect to empty models

### DIFF
--- a/src/parameter_inspection.jl
+++ b/src/parameter_inspection.jl
@@ -30,8 +30,8 @@ function params(m, ::Val{true})
     return NamedTuple{fields}(Tuple([params(getfield(m, field)) for field in fields]))
 end
 
-isamodel(::Any) = false
-isamodel(::Model) = true
+isnotaleaf(::Any) = false
+isnotaleaf(m::Model) = length(propertynames(m)) > 0
 
 """
     flat_params(m::Model)
@@ -53,13 +53,10 @@ not a hard requirement.
      parallel = true,)
 
 """
-flat_params(m; prefix="") = flat_params(m, Val(isamodel(m)); prefix=prefix)
+flat_params(m; prefix="") = flat_params(m, Val(isnotaleaf(m)); prefix=prefix)
 flat_params(m, ::Val{false}; prefix="") = NamedTuple{(Symbol(prefix),), Tuple{Any}}((m,))
 function flat_params(m, ::Val{true}; prefix="")
     fields = propertynames(m)
-    if isempty(fields)
-        return NamedTuple{(Symbol(prefix),)}((m,))
-    end
     prefix = prefix == "" ? "" : prefix * "__"
     merge([flat_params(getproperty(m, field); prefix="$(prefix)$(field)") for field in fields]...)
 end

--- a/src/parameter_inspection.jl
+++ b/src/parameter_inspection.jl
@@ -57,6 +57,9 @@ flat_params(m; prefix="") = flat_params(m, Val(isamodel(m)); prefix=prefix)
 flat_params(m, ::Val{false}; prefix="") = NamedTuple{(Symbol(prefix),), Tuple{Any}}((m,))
 function flat_params(m, ::Val{true}; prefix="")
     fields = propertynames(m)
+    if isempty(fields)
+        return NamedTuple{(Symbol(prefix),)}((m,))
+    end
     prefix = prefix == "" ? "" : prefix * "__"
     merge([flat_params(getproperty(m, field); prefix="$(prefix)$(field)") for field in fields]...)
 end

--- a/test/parameter_inspection.jl
+++ b/test/parameter_inspection.jl
@@ -35,8 +35,8 @@ end
 end
 
 struct ChildModel <: Model
-    x::Int
-    y::String
+    r::Int
+    s
 end
 
 struct ParentModel <: Model
@@ -46,18 +46,20 @@ struct ParentModel <: Model
     second_child::ChildModel
 end
 
+struct Missy <: Model end
+
 @testset "flat_params method" begin
 
     m = ParentModel(1, "parent", ChildModel(2, "child1"),
-        ChildModel(3, "child2"))
+        ChildModel(3, Missy()))
 
     @test MLJModelInterface.flat_params(m) == (
         x = 1,
         y = "parent",
-        first_child__x = 2,
-        first_child__y = "child1",
-        second_child__x = 3,
-        second_child__y = "child2"
+        first_child__r = 2,
+        first_child__s = "child1",
+        second_child__r = 3,
+        second_child__s = Missy()
     )
 end
 true


### PR DESCRIPTION
#177 missed the capability to get the tuple representation from an empty struct property. This PR solves that specific problem by adding a race condition.