### PR TITLE
For a 1.9.4 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModelInterface"
 uuid = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 authors = ["Thibaut Lienart and Anthony Blaom"]
-version = "1.9.3"
+version = "1.9.4"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/model_def.jl
+++ b/src/model_def.jl
@@ -141,7 +141,7 @@ function _model_constructor(modelname, params, defaults)
         Expr(
             :block,
             Expr(:(=), :model, Expr(:call, :new, params...)),
-            :(message = MLJModelInterface.clean!(model)),
+            :(message = $MLJModelInterface.clean!(model)),
 			:(isempty(message) || @warn message),
 			:(return model)
 		)
@@ -158,7 +158,7 @@ in a model def.
 function _model_cleaner(modelname, defaults, constraints)
     Expr(
         :function,
-        :(MLJModelInterface.clean!(model::$modelname)),
+        :($MLJModelInterface.clean!(model::$modelname)),
         # body of the function
         Expr(
             :block,


### PR DESCRIPTION
Fixes `@mlj_model` for packages that only `import MLJModelInterface` instead of `using MLJModelInterface`. 