### PR TITLE
Tweak fit_data_scitype fallback to resolve issue with class weights

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJModelInterface"
 uuid = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 authors = ["Thibaut Lienart and Anthony Blaom"]
-version = "1.9.5"
+version = "1.9.6"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/model_traits.jl
+++ b/src/model_traits.jl
@@ -59,7 +59,7 @@ function supervised_fit_data_scitype(M)
         W = AbstractVector{<:Union{Continuous, Count}} # weight scitype
         return Union{ret, Tuple{I, T, W}}
     elseif supports_class_weights(M)
-        W = AbstractDict{Finite, <:Union{Continuous, Count}}
+        W = Any
         return Union{ret, Tuple{I, T, W}}
     end
     return ret


### PR DESCRIPTION
Resolves #170.

We need an `Any` type where we had `AbstractDict{...}`, which doesn't make sense, because currently dictionaries have `Unknown` scitype, unless they are keyed on integer (multisets). 