### PR TITLE
Replace broken alan-turing-institute links

### DIFF
--- a/src/metadata_utils.jl
+++ b/src/metadata_utils.jl
@@ -71,7 +71,7 @@ depwarn_docstring(T) =
     Regarding $T: `metadata_model` should not be called with the keyword argument `descr`
     or `docstring`. Implementers of the MLJ model interface should instead create an
     MLJ-compliant docstring in the usual way.  See
-    https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/#Document-strings
+    https://juliaai.github.io/MLJ.jl/dev/adding_models_for_general_use/#Document-strings
     for details.
 
     """

--- a/src/model_api.jl
+++ b/src/model_api.jl
@@ -47,7 +47,7 @@ The following trait overload is also required:
 training_losses(model, report) = nothing
 
 # to support online learning in the future:
-# https://github.com/alan-turing-institute/MLJ.jl/issues/60 :
+# https://github.com/JuliaAI/MLJ.jl/issues/60 :
 function update_data end
 
 """
@@ -67,7 +67,7 @@ the model-specific representations of the data.
 
 To implement the `reformat` data front-end for a model, refer to
 "Implementing a data front-end" in the [MLJ
-manual](https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/).
+manual](https://juliaai.github.io/MLJ.jl/dev/adding_models_for_general_use/).
 
 
 """


### PR DESCRIPTION
I have simply applied the same changes that were done for MLJ.jl in https://github.com/JuliaAI/MLJ.jl/pull/1113.