### PR TITLE
Fix doc links and Base.Docs.doc issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: julia-actions/cache@v1
         env:
           cache-name: cache-artifacts
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Thibaut Lienart and Anthony Blaom"]
 version = "1.11.0"
 
 [deps]
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ScientificTypesBase = "30f210dd-8aff-4c5f-94ba-8e64358c1161"
 StatisticalTraits = "64bff920-2084-43da-a3e6-9bb72801c0c9"
@@ -16,6 +17,7 @@ Distances = "0.10"
 InteractiveUtils = "<0.0.1, 1"
 Markdown = "<0.0.1, 1"
 OrderedCollections = "1"
+REPL = "<0.0.1, 1"
 Random = "<0.0.1, 1"
 ScientificTypes = "3"
 ScientificTypesBase = "3"

--- a/src/MLJModelInterface.jl
+++ b/src/MLJModelInterface.jl
@@ -63,6 +63,7 @@ const ABSTRACT_MODEL_SUBTYPES = [
 using ScientificTypesBase
 using StatisticalTraits
 using Random
+using REPL # apparently needed to get Base.Docs.doc to work
 
 import StatisticalTraits: info
 

--- a/src/metadata_utils.jl
+++ b/src/metadata_utils.jl
@@ -71,7 +71,7 @@ depwarn_docstring(T) =
     Regarding $T: `metadata_model` should not be called with the keyword argument `descr`
     or `docstring`. Implementers of the MLJ model interface should instead create an
     MLJ-compliant docstring in the usual way.  See
-    https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/#Document-strings
+    https://juliaai.github.io/MLJ.jl/dev/adding_models_for_general_use/#Document-strings
     for details.
 
     """

--- a/src/model_api.jl
+++ b/src/model_api.jl
@@ -47,7 +47,7 @@ The following trait overload is also required:
 training_losses(model, report) = nothing
 
 # to support online learning in the future:
-# https://github.com/alan-turing-institute/MLJ.jl/issues/60 :
+# https://github.com/JuliaAI/MLJ.jl/issues/60 :
 function update_data end
 
 """
@@ -67,7 +67,7 @@ the model-specific representations of the data.
 
 To implement the `reformat` data front-end for a model, refer to
 "Implementing a data front-end" in the [MLJ
-manual](https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/).
+manual](https://juliaai.github.io/MLJ.jl/dev/adding_models_for_general_use/).
 
 
 """


### PR DESCRIPTION
Replaces #216 and additionally:

- fixes an issue with Base.Docs.doc, which in Julia 1.11 will not work unless REPL is a dependency. See https://discourse.julialang.org/t/base-docs-doc-failing-with-1-11-0/121187/3 .

- updates actions/cache@v1 to Julia-actions/cache@v1 to fix outdated GH action
