### PR TITLE
Tweak overloading of `Base.in`

### DIFF
--- a/src/equality.jl
+++ b/src/equality.jl
@@ -158,6 +158,7 @@ Base.in(x::MLJType, itr::Set) = special_in(x, itr)
 Base.in(x::MLJType, itr::AbstractVector{<:MLJType}) = special_in(x, itr)
 Base.in(x::MLJType, itr::AbstractRange{<:MLJType}) = special_in(x, itr)
 Base.in(x::MLJType, itr::Tuple) = special_in(x, itr)
+Base.in(x::MLJType, itr::Tuple{(Any for _ in 1:32)..., Vararg{Any}}) = special_in(x, itr)
 
 # A version of `in` that actually uses `==`:
 


### PR DESCRIPTION
Replaces https://github.com/JuliaAI/MLJModelInterface.jl/pull/200

Local testing of downstream packages:

-  [x] MLJTuning
-  [x] MLJEnsembles
-  [x] MLJIteration
-  [x] FeatureSelection
-  [x] MLJ (including integration tests)